### PR TITLE
解决因 input name 值错误导致无法给文章加密的问题

### DIFF
--- a/admin/write-post.php
+++ b/admin/write-post.php
@@ -89,7 +89,7 @@ Typecho_Widget::widget('Widget_Contents_Post_Edit')->to($post);
                             <ul>
                                 <?php if ($user->pass('editor', true)): ?>
                                 <li><input id="publish" value="publish" name="visibility" type="radio"<?php if (($post->status == 'publish' && !$post->password) || !$post->status) { ?> checked="true"<?php } ?> /> <label for="publish"><?php _e('公开'); ?></label></li>
-                                <li><input id="password" value="password" name="visibility" type="radio"<?php if ($post->password) { ?> checked="true"<?php } ?> /> <label for="password">密码保护 <input type="text" id="post-password" name="post-password" class="text-s" value="<?php $post->password(); ?>" size="16" /></label></li>
+                                <li><input id="password" value="password" name="visibility" type="radio"<?php if ($post->password) { ?> checked="true"<?php } ?> /> <label for="password">密码保护 <input type="text" id="post-password" name="password" class="text-s" value="<?php $post->password(); ?>" size="16" /></label></li>
                                 <li><input id="private" value="private" name="visibility" type="radio"<?php if ($post->status == 'private') { ?> checked="true"<?php } ?> /> <label for="private">私密</label></li>
                                 <?php endif; ?>
                                 <li><input id="waiting" value="waiting" name="visibility" type="radio"<?php if (!$user->pass('editor', true) || $post->status == 'waiting') { ?> checked="true"<?php } ?> /> <label for="waiting">待审核</label></li>


### PR DESCRIPTION
设置密码保护的 input 的 name 值是 post-password，但后端期待的却是 $_POST['password'] 导致因取不到密码，而没法把文章的状态设为密码保护。
