### PR TITLE
添加插件句柄

### DIFF
--- a/var/Widget/Contents/Post/Edit.php
+++ b/var/Widget/Contents/Post/Edit.php
@@ -719,6 +719,10 @@ class Widget_Contents_Post_Edit extends Widget_Abstract_Contents implements Widg
             /** 发送ping */
             $trackback = array_unique(preg_split("/(\r|\n|\r\n)/", trim($this->request->trackback)));
             $this->widget('Widget_Service')->sendPing($this->cid, $trackback);
+            
+            if ('publish' == $this->status) {
+                $this->pluginHandle()->finishWritePost($contents, $this);
+            }
 
             /** 设置提示信息 */
             $this->widget('Widget_Notice')->set('post' == $this->type ?
@@ -814,6 +818,8 @@ class Widget_Contents_Post_Edit extends Widget_Abstract_Contents implements Widg
 
                 unset($condition);
             }
+            
+            $this->pluginHandle()->finishDeletePost($cid, $this);
         }
 
         /** 设置提示信息 */


### PR DESCRIPTION
在文章发布成功和删除后添加插件句柄，以供一些需要获取当前文章ID或删除文章后需要更新某些如 sitemap 文件的插件使用。（如果审核通过，相应的 Page/Edit.php 也需要能添加上~）
