### PR TITLE
修复包含大写字母的邮箱获取Gravatar头像错误问题

### DIFF
--- a/admin/profile.php
+++ b/admin/profile.php
@@ -12,7 +12,7 @@ $stat = Typecho_Widget::widget('Widget_Stat');
         <div class="row typecho-page-main">
             <div class="col-mb-12 col-tb-3">
                 <p><a href="http://gravatar.com/emails/" title="<?php _e('在 Gravatar 上修改头像'); ?>"><?php echo '<img class="profile-avatar" src="'
-                    . ($request->isSecure() ? 'https://secure' : 'http://www') . '.gravatar.com/avatar/' . md5($user->mail) . '?s=220&r=X' .
+                    . ($request->isSecure() ? 'https://secure' : 'http://www') . '.gravatar.com/avatar/' . md5(strtolower($user->mail)) . '?s=220&r=X' .
                 '&d=mm" alt="' . $user->screenName . '" />'; ?></a></p>
                 <h2><?php $user->screenName(); ?></h2>
                 <p><?php $user->name(); ?></p>

--- a/var/Widget/Abstract/Users.php
+++ b/var/Widget/Abstract/Users.php
@@ -239,7 +239,7 @@ class Widget_Abstract_Users extends Widget_Abstract
     public function gravatar($size = 40, $rating = 'X', $default = NULL, $class = NULL)
     {
         echo '<img' . (empty($class) ? '' : ' class="' . $class . '"') . ' src="http://www.gravatar.com/avatar/' .
-        md5($this->mail) . '?s=' . $size . '&amp;r=' . $rating . '&amp;d=' . $default . '" alt="' .
+        md5(strtolower($this->mail)) . '?s=' . $size . '&amp;r=' . $rating . '&amp;d=' . $default . '" alt="' .
         $this->screenName . '" width="' . $size . '" height="' . $size . '" />';
     }
 }


### PR DESCRIPTION
修复用户抽象类及后台个人设置中，包含大写字母的邮箱获取Gravatar头像错误问题。

_（评论基类无此问题）_
