### PR TITLE
代码高亮的语言加入“纯文本”

### DIFF
--- a/var/MarkdownExtraExtended.php
+++ b/var/MarkdownExtraExtended.php
@@ -3247,7 +3247,13 @@ class MarkdownExtraExtended extends MarkdownExtra {
 		//$codeblock = "<pre><code>$codeblock</code></pre>";
 		//$cb = "<pre><code";
 		$cb = empty($matches[3]) ? "<pre><code" : "<pre class=\"linenums:$matches[3]\"><code"; 
-		$cb .= empty($matches[2]) ? ">" : " class=\"lang-$matches[2]\">";
+		if (empty($matches[2])) {
+        		$cb .= ">";
+    		} else if (in_array($matches[2], array("plain", "text", "txt"))) {
+        		$cb .= " class=\"no-highlight\">";
+    		} else {
+        		$cb .= " class=\"lang-$matches[2]\">";
+    		}
 		$cb .= "$codeblock</code></pre>";
 		return "\n\n".$this->hashBlock($cb)."\n\n";
 	}


### PR DESCRIPTION
``````
```plain
这里的代码块不会高亮。
```
``````

也可以使用 `text`或 `txt`。

配合highlight.js使用，例如 [the HighlightJs-1.0.1 typecho 插件](http://70.io/develop/highlight-js-typecho-plugin.html)。

Using `plain` and `text` as markup is inspired by [沙渺](http://segmentfault.com/q/1010000000354936)。
