### PR TITLE
注释掉请求Token验证，以解决强制启用rewrite功能失效的问题，同时增加Token错误时的显示信息

### DIFF
--- a/var/Widget/Options/Permalink.php
+++ b/var/Widget/Options/Permalink.php
@@ -66,8 +66,6 @@ class Widget_Options_Permalink extends Widget_Abstract_Options implements Widget
         $currentTable = $parser->parse();
         $regx = $currentTable['custom']['regx'];
 
-        //echo $regx; die;
-
         foreach ($routingTable as $key => $val) {
             if ('post' != $key && 'page' != $key) {
                 $pathInfo = preg_replace("/\[([_a-z0-9-]+)[^\]]*\]/i", "{\\1}", $val['url']);

--- a/var/Widget/Security.php
+++ b/var/Widget/Security.php
@@ -75,6 +75,10 @@ class Widget_Security extends Typecho_Widget
     public function protect()
     {
         if ($this->request->get('_') != $this->getToken($this->request->getReferer())) {
+            echo 'Token Error Info:<br />';
+            echo 'RequestToken='.$this->request->get('_').'<br />';
+            echo 'RefererToken='.$this->getToken($this->request->getReferer());
+            exit();
             $this->response->goBack();
         }
     }


### PR DESCRIPTION
注释掉请求Token验证，以解决强制启用rewrite功能失效的问题，同时增加Token错误时的显示信息
