### PR TITLE
Typecho_Http_Client_Adapter 中 $this->path 可能不拼接 query string

### DIFF
--- a/var/Typecho/Http/Client/Adapter.php
+++ b/var/Typecho/Http/Client/Adapter.php
@@ -315,6 +315,7 @@ abstract class Typecho_Http_Client_Adapter
             $this->path .= '?' . $params['query'] . (empty($this->query) ? NULL : '&' . $this->query);
             $url .= (empty($this->query) ? NULL : '&' . $this->query);
         } else {
+            $this->path .= (empty($this->query) ? NULL : '?' . $this->query);
             $url .= (empty($this->query) ? NULL : '?' . $this->query);
         }
 


### PR DESCRIPTION
调用 `send()` 时，若传入的 `$url` 参数中没有 query string 部分，则即便之前调用了 `setQuery()`，query string 也不会被拼接到 `$this->path` 中，导致 query string 不被传递。
