### PR TITLE
修复两个在SAE本地环境出现的bug

### DIFF
--- a/install/Mysql.php
+++ b/install/Mysql.php
@@ -3,7 +3,7 @@
 <?php
 $engine = '';
 
-if (defined('SAE_MYSQL_DB')) {
+if (defined('SAE_MYSQL_DB') && SAE_MYSQL_DB != "app_") {
     $engine = 'SAE';
 } else if (!!getenv('HTTP_BAE_ENV_ADDR_SQL_IP')) {
     $engine = 'BAE';

--- a/var/Typecho/Common.php
+++ b/var/Typecho/Common.php
@@ -9,7 +9,7 @@
  * @version $Id$
  */
 
-define('__TYPECHO_MB_SUPPORTED__', function_exists('mb_get_info'));
+define('__TYPECHO_MB_SUPPORTED__', function_exists('mb_get_info') && function_exists('mb_regex_encoding'));
 
 /**
  * Typecho公用方法


### PR DESCRIPTION
使用[SAE本地环境](http://sae.sina.com.cn/doc/download.html)时遇到下面两个问题：

* 安装时提示如下的错误，注意错误信息为空字符串，并没有其他任何有用信息：

> 安装程序捕捉到以下错误:"". 程序被终止, 请检查您的配置信息.

原因是SAE本地环境下，虽然像`SAE_MYSQL_DB`这样的常量是定义了的，但并没有正确赋值，默认情况下`SAE_MYSQL_USER`和`SAE_MYSQL_PASS`都为空，导致安装时报错。

* 后台添加分类或启用插件或其他一些和Common.php中`slugName`函数相关的操作都会出现错误：

> Fatal error: Call to undefined function mb_regex_encoding() in typecho\var\Typecho\Common.php on line 810

原因是`mb_regex_encoding`函数在某些Windows下的PHP环境中没有定义，但是`mb_get_info`函数是定义了的。
