### PR TITLE
Adds strikethrough syntax just like GFM

### DIFF
--- a/admin/css/style.css
+++ b/admin/css/style.css
@@ -1389,6 +1389,32 @@ a.operate-reply {
 .tDnD_whileDrag {
   background-color: #FFFBCC; }
 
+/* 文章/页面筛选 */
+.subsubsub {
+  list-style: none;
+  margin: 0 8px;
+  padding: 0;
+  font-size: 13px;
+  color: #666;
+  display: inline-block;
+}
+.subsubsub li {
+  display: inline-block;
+  margin: 0;
+  padding: 0;
+  white-space: nowrap;
+}
+.subsubsub a {
+  line-height: 2;
+  padding: .2em;
+  text-decoration: none;
+}
+.subsubsub a.current {
+  color: #000;
+  font-weight: 600;
+  border: none;
+}
+
 /**
 * 导入扩展样式
 */

--- a/admin/manage-pages.php
+++ b/admin/manage-pages.php
@@ -17,9 +17,20 @@ $stat = Typecho_Widget::widget('Widget_Stat');
                             <div class="btn-group btn-drop">
                             <button class="btn dropdown-toggle btn-s" type="button"><i class="sr-only"><?php _e('操作'); ?></i><?php _e('选中项'); ?> <i class="i-caret-down"></i></button>
                             <ul class="dropdown-menu">
-                                <li><a lang="<?php _e('你确认要删除这些页面吗?'); ?>" href="<?php $security->index('/action/contents-page-edit?do=delete'); ?>"><?php _e('删除'); ?></a></li>
+                                <li><a lang="<?php _e('你确认要删除这些页面吗?'); ?>" href="<?php $security->index('/action/contents-page-edit?do=delete'); ?>"><?php _e('彻底删除'); ?></a></li>
+                                <?php if ($request->status != "trash"): ?>
+                                <li><a lang="<?php _e('你确认要删除这些页面吗?'); ?>" href="<?php $security->index('/action/contents-page-edit?do=trash'); ?>"><?php _e('移到回收站'); ?></a></li>
+                                <?php else: ?>
+                                <li><a lang="<?php _e('你确认要还原这些页面吗?'); ?>" href="<?php $security->index('/action/contents-page-edit?do=untrash'); ?>"><?php _e('还原'); ?></a></li>	
+                                <?php endif; ?>
                             </ul>
                             </div>
+                            <ul class="subsubsub">
+								<li class="all"><a href="<?php $options->adminUrl('manage-pages.php?status=all'); ?>" class="<?= (empty($request->status) || $request->status == "all") ? "current" : "" ?>"><?php _e("全部") ?></a> |</li>
+								<li class="publish"><a href="<?php $options->adminUrl('manage-pages.php?status=publish'); ?>" class="<?= ($request->status == "publish") ? "current" : "" ?>"><?php _e("已发布") ?></a> |</li>
+								<li class="publish"><a href="<?php $options->adminUrl('manage-pages.php?status=draft'); ?>" class="<?= ($request->status == "draft") ? "current" : "" ?>"><?php _e("草稿") ?></a> |</li>
+								<li class="trash"><a href="<?php $options->adminUrl('manage-pages.php?status=trash'); ?>" class="<?= ($request->status == "trash") ? "current" : "" ?>"><?php _e("回收站") ?></a></li>
+							</ul>
                         </div>
 
                         <div class="search" role="search">

--- a/admin/manage-posts.php
+++ b/admin/manage-posts.php
@@ -17,9 +17,20 @@ $stat = Typecho_Widget::widget('Widget_Stat');
                             <div class="btn-group btn-drop">
                                 <button class="btn dropdown-toggle btn-s" type="button"><i class="sr-only"><?php _e('操作'); ?></i><?php _e('选中项'); ?> <i class="i-caret-down"></i></button>
                                 <ul class="dropdown-menu">
-                                    <li><a lang="<?php _e('你确认要删除这些文章吗?'); ?>" href="<?php $security->index('/action/contents-post-edit?do=delete'); ?>"><?php _e('删除'); ?></a></li>
+                                    <li><a lang="<?php _e('你确认要删除这些文章吗?'); ?>" href="<?php $security->index('/action/contents-post-edit?do=delete'); ?>"><?php _e('彻底删除'); ?></a></li>
+                                    <?php if ($request->status != "trash"): ?>
+                                    <li><a lang="<?php _e('你确认要删除这些文章吗?'); ?>" href="<?php $security->index('/action/contents-post-edit?do=trash'); ?>"><?php _e('移到回收站'); ?></a></li>
+                                    <?php else: ?>
+                                    <li><a lang="<?php _e('你确认要还原这些文章吗?'); ?>" href="<?php $security->index('/action/contents-post-edit?do=untrash'); ?>"><?php _e('还原'); ?></a></li>	
+                                    <?php endif; ?>
                                 </ul>
                             </div>  
+                            <ul class="subsubsub">
+								<li class="all"><a href="<?php $options->adminUrl('manage-posts.php?status=all'); ?>" class="<?= (empty($request->status) || $request->status == "all") ? "current" : "" ?>"><?php _e("全部") ?></a> |</li>
+								<li class="publish"><a href="<?php $options->adminUrl('manage-posts.php?status=publish'); ?>" class="<?= ($request->status == "publish") ? "current" : "" ?>"><?php _e("已发布") ?></a> |</li>
+								<li class="publish"><a href="<?php $options->adminUrl('manage-posts.php?status=draft'); ?>" class="<?= ($request->status == "draft") ? "current" : "" ?>"><?php _e("草稿") ?></a> |</li>
+								<li class="trash"><a href="<?php $options->adminUrl('manage-posts.php?status=trash'); ?>" class="<?= ($request->status == "trash") ? "current" : "" ?>"><?php _e("回收站") ?></a></li>
+							</ul>
                         </div>
                         <div class="search" role="search">
                             <?php if ('' != $request->keywords || '' != $request->category): ?>

--- a/admin/scss/style.scss
+++ b/admin/scss/style.scss
@@ -937,6 +937,31 @@ background: #FFF1A8;
   background-color: #FFFBCC;
 }
 
+/* 文章/页面筛选 */
+.subsubsub {
+  list-style: none;
+  margin: 0 8px;
+  padding: 0;
+  font-size: 13px;
+  color: #666;
+  display: inline-block;
+  li {
+    display: inline-block;
+    margin: 0;
+    padding: 0;
+    white-space: nowrap;    
+  }
+  a {
+    line-height: 2;
+    padding: .2em;
+    text-decoration: none;
+  }
+  a.current {
+    color: #000;
+    font-weight: 600;
+    border: none;
+  }
+} 
 
 /**
 * 导入扩展样式

--- a/var/MarkdownExtraExtended.php
+++ b/var/MarkdownExtraExtended.php
@@ -3146,7 +3146,9 @@ class MarkdownExtraExtended extends MarkdownExtra {
         $this->document_gamut += array(
             "doClearBreaks"     =>  100
         );
-		
+        $this->span_gamut += array(
+            "doStrikethroughs" => -35
+        );
 		parent::__construct();
 	}
 
@@ -3297,6 +3299,22 @@ class MarkdownExtraExtended extends MarkdownExtra {
 		}
 		$res .= "</figure>";		
 		return "\n". $this->hashBlock($res)."\n\n";
+	}
+	
+	public function doStrikethroughs($text) {
+	#
+	# Replace ~~some deleted text~~ with <del>some deleted text</del>
+	#
+		$text = preg_replace_callback('{
+				~~([^~]+)~~
+			}xm',
+			array(&$this, '_doStrikethroughs_callback'), $text);
+		return $text;
+	}
+	
+	public function _doStrikethroughs_callback($matches) {
+		$res = "<del>" . $matches[1] . "</del>";
+		return $this->hashBlock($res);
 	}
 }
 

--- a/var/Widget/Contents/Page/Admin.php
+++ b/var/Widget/Contents/Page/Admin.php
@@ -29,8 +29,26 @@ class Widget_Contents_Page_Admin extends Widget_Contents_Post_Admin
     public function execute()
     {
         /** 过滤状态 */
-        $select = $this->select()->where('table.contents.type = ? OR (table.contents.type = ? AND table.contents.parent = ?)', 'page', 'page_draft', 0);
-
+        $select = $this->select();
+		if ($this->request->status == "publish") {
+			// 显示已发布
+			$select->where('table.contents.type = ? AND table.contents.status = ?', 'page', 'publish');
+		}
+		else if ($this->request->status == "draft") {
+			// 显示草稿
+			$select->where('table.contents.type = ? AND table.contents.status = ?', 'page_draft', 'publish');
+		}
+		else if ($this->request->status == "trash") {
+			// 显示回收站
+			$select->where('table.contents.type = ? OR (table.contents.type = ? AND table.contents.parent = ?)', 'page', 'page_draft', 0);
+			$select->where('table.contents.status = ?', 'trash');
+		}
+		else {
+			// 显示所有（除回收站）
+			$select->where('table.contents.type = ? OR (table.contents.type = ? AND table.contents.parent = ?)', 'page', 'page_draft', 0);
+			$select->where('table.contents.status != ?', 'trash');
+		}
+		
         /** 过滤标题 */
         if (NULL != ($keywords = $this->request->keywords)) {
             $args = array();

--- a/var/Widget/Contents/Post/Admin.php
+++ b/var/Widget/Contents/Post/Admin.php
@@ -94,8 +94,26 @@ class Widget_Contents_Post_Admin extends Widget_Abstract_Contents
         $this->_currentPage = $this->request->get('page', 1);
 
         /** 构建基础查询 */
-        $select = $this->select()->where('table.contents.type = ? OR (table.contents.type = ? AND table.contents.parent = ?)', 'post', 'post_draft', 0);
-
+        $select = $this->select();
+		if ($this->request->status == "publish") {
+			// 显示已发布
+			$select->where('table.contents.type = ? AND table.contents.status = ?', 'post', 'publish');
+		}
+		else if ($this->request->status == "draft") {
+			// 显示草稿
+			$select->where('table.contents.type = ? AND table.contents.status = ?', 'post_draft', 'publish');
+		}
+		else if ($this->request->status == "trash") {
+			// 显示回收站
+			$select->where('table.contents.type = ? OR (table.contents.type = ? AND table.contents.parent = ?)', 'post', 'post_draft', 0);
+			$select->where('table.contents.status = ?', 'trash');
+		}
+		else {
+			// 显示所有（除回收站）
+			$select->where('table.contents.type = ? OR (table.contents.type = ? AND table.contents.parent = ?)', 'post', 'post_draft', 0);
+			$select->where('table.contents.status != ?', 'trash');
+		}
+		
         /** 过滤分类 */
         if (NULL != ($category = $this->request->category)) {
             $select->join('table.relationships', 'table.contents.cid = table.relationships.cid')

--- a/var/Widget/Contents/Post/Edit.php
+++ b/var/Widget/Contents/Post/Edit.php
@@ -898,6 +898,32 @@ class Widget_Contents_Post_Edit extends Widget_Abstract_Contents implements Widg
     }
 
     /**
+     * 将页面移到回收站
+     *
+     * @access public
+     * @return void
+     */
+    public function trashPost($status)
+    {
+        $pages = $this->request->filter('int')->getArray('cid');
+        $deleteCount = 0;
+
+        foreach ($pages as $page) {
+            $this->db->query($this->db->update('table.contents')->rows(array('status' => $status))
+                ->where('cid = ?', $page));
+            $deleteCount++;
+        }
+
+        /** 设置提示信息 */
+        $msg = $status == "trash" ? _t('已经移到回收站') : _t('已经还原');
+        $this->widget('Widget_Notice')->set($deleteCount > 0 ? $msg : _t('没有操作'),
+        $deleteCount > 0 ? 'success' : 'notice');
+        
+        /** 返回原网页 */
+        $this->response->goBack();
+    }
+
+    /**
      * 绑定动作
      *
      * @access public
@@ -908,6 +934,8 @@ class Widget_Contents_Post_Edit extends Widget_Abstract_Contents implements Widg
         $this->security->protect();
         $this->on($this->request->is('do=publish') || $this->request->is('do=save'))->writePost();
         $this->on($this->request->is('do=delete'))->deletePost();
+		$this->on($this->request->is('do=trash'))->trashPost('trash');
+		$this->on($this->request->is('do=untrash'))->trashPost('publish');
         $this->on($this->request->is('do=deleteDraft'))->deletePostDraft();
         $this->on($this->request->is('do=preview'))->preview();
 


### PR DESCRIPTION
由于后台编辑预览博客和前台显示博客所使用的Markdown程序不一致，后台使用的是pagedown.js实时预览，而前台使用的是php-markdown-extra-extended，导致有些Markdown语法在预览时是OK的，但是发布博客后却有问题。譬如删除线语法就是个例子（参考[GFM文档](https://help.github.com/articles/github-flavored-markdown/#strikethrough)），pagedown.js实现了GFM中的这个语法，而php-markdown-extra-extended没有实现。所以我修改了php-markdown-extra-extended以支持删除线语法，并提交了[PR](https://github.com/egil/php-markdown-extra-extended/pull/10)。

实现其实很简单，将`~~delete~~`替换为`<del>delete</del>`即可。
希望对项目有帮助。

另外，只要两个库支持的Markdown语法不一致，这种问题应该还会在其他语法上出现。