### PR TITLE
Adds strikethrough syntax just like GFM

### DIFF
--- a/var/MarkdownExtraExtended.php
+++ b/var/MarkdownExtraExtended.php
@@ -3146,7 +3146,9 @@ class MarkdownExtraExtended extends MarkdownExtra {
         $this->document_gamut += array(
             "doClearBreaks"     =>  100
         );
-		
+        $this->span_gamut += array(
+            "doStrikethroughs" => -35
+        );
 		parent::__construct();
 	}
 
@@ -3297,6 +3299,22 @@ class MarkdownExtraExtended extends MarkdownExtra {
 		}
 		$res .= "</figure>";		
 		return "\n". $this->hashBlock($res)."\n\n";
+	}
+	
+	public function doStrikethroughs($text) {
+	#
+	# Replace ~~some deleted text~~ with <del>some deleted text</del>
+	#
+		$text = preg_replace_callback('{
+				~~([^~]+)~~
+			}xm',
+			array(&$this, '_doStrikethroughs_callback'), $text);
+		return $text;
+	}
+	
+	public function _doStrikethroughs_callback($matches) {
+		$res = "<del>" . $matches[1] . "</del>";
+		return $this->hashBlock($res);
 	}
 }
 


### PR DESCRIPTION
由于后台编辑预览博客和前台显示博客所使用的Markdown程序不一致，后台使用的是pagedown.js实时预览，而前台使用的是php-markdown-extra-extended，导致有些Markdown语法在预览时是OK的，但是发布博客后却有问题。譬如删除线语法就是个例子（参考[GFM文档](https://help.github.com/articles/github-flavored-markdown/#strikethrough)），pagedown.js实现了GFM中的这个语法，而php-markdown-extra-extended没有实现。所以我修改了php-markdown-extra-extended以支持删除线语法，并提交了[PR](https://github.com/egil/php-markdown-extra-extended/pull/10)。

实现其实很简单，将`~~delete~~`替换为`<del>delete</del>`即可。
希望对项目有帮助。

另外，只要两个库支持的Markdown语法不一致，这种问题应该还会在其他语法上出现。