### PR TITLE
删除 Chrome Frame 的支持

### DIFF
--- a/usr/themes/default/header.php
+++ b/usr/themes/default/header.php
@@ -3,7 +3,7 @@
 <html class="no-js">
 <head>
     <meta charset="<?php $this->options->charset(); ?>">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="renderer" content="webkit">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title><?php $this->archiveTitle(array(


### PR DESCRIPTION
Google Chrome Frame已于2014年2月25日正式停止维护与更新 https://zh.wikipedia.org/wiki/Google_Chrome_Frame