### PR TITLE
Json.php 中的引用错误

### DIFF
--- a/var/Json.php
+++ b/var/Json.php
@@ -225,7 +225,7 @@ class Json
 
             case 'array':
                 if (is_array($var) && count($var) && (array_keys($var) !== range(0, sizeof($var) - 1))) {
-                    $properties = array_map(array('Typecho_Json', '_name_value'),
+                    $properties = array_map(array('Json', '_name_value'),
                                             array_keys($var),
                                             array_values($var));
 
@@ -239,7 +239,7 @@ class Json
                 }
 
                 // treat it like a regular array
-                $elements = array_map(array('Typecho_Json', '_encode'), $var);
+                $elements = array_map(array('Json', '_encode'), $var);
 
                 foreach ($elements as $element) {
                     if (self::_is_error($element)) {
@@ -252,7 +252,7 @@ class Json
             case 'object':
                 $vars = get_object_vars($var);
 
-                $properties = array_map(array('Typecho_Json', '_name_value'),
+                $properties = array_map(array('Json', '_name_value'),
                                         array_keys($vars),
                                         array_values($vars));
 


### PR DESCRIPTION
虽然我都改成了 `Json` 但是我觉得用 `$this` 应该会更方便一点，而且事实上 http://mike.teczno.com/JSON/JSON.phps 源库文件好像也就是这么用的。