### PR TITLE
添加文件缓存，减少不必要的字符串匹配操作

### DIFF
--- a/cache/contents/.gitignore
+++ b/cache/contents/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
#397 
为了解决397的问题。
给Widget_Abstract_Contents的三个方法：
___description()
___excerpt()
___content()
添加增加文件缓存的过程，通过增加文件缓存之后，减少了很多不必要的字符串的匹配的操作。
为了能够正常的生成缓存，需要给cache/contents文件读写的权限。