### PR TITLE
修复使用Typecho_Plugin::factory('admin/header.php')->header接口覆盖后台样式的问题

### DIFF
--- a/admin/header.php
+++ b/admin/header.php
@@ -12,7 +12,7 @@ $header = '<link rel="stylesheet" href="' . Typecho_Common::url('normalize.css?v
 <![endif]-->';
 
 /** 注册一个初始化插件 */
-$header = Typecho_Plugin::factory('admin/header.php')->header($header);
+$header = $header . Typecho_Plugin::factory('admin/header.php')->header();
 
 ?><!DOCTYPE HTML>
 <html class="no-js">


### PR DESCRIPTION
见文件`admin/header.php`第15行和26行，若在插件中注册Typecho_Plugin::factory('admin/header.php')->header接口并启用插件，导致原`$header`内容被覆盖。