### PR TITLE
update PHPDoc comments

### DIFF
--- a/var/Typecho/Router.php
+++ b/var/Typecho/Router.php
@@ -110,9 +110,8 @@ class Typecho_Router
     /**
      * 路由分发函数
      *
-     * @param string $path 目的文件所在目录
      * @return void
-     * @throws Typecho_Route_Exception
+     * @throws Typecho_Router_Exception
      */
     public static function dispatch()
     {
@@ -159,7 +158,7 @@ class Typecho_Router
      * 路由反解析函数
      *
      * @param string $name 路由配置表名称
-     * @param string $value 路由填充值
+     * @param array $value 路由填充值
      * @param string $prefix 最终合成路径的前缀
      * @return string
      */
@@ -200,7 +199,7 @@ class Typecho_Router
      * @param string $routeName 路由名称
      * @static
      * @access public
-     * @return void
+     * @return mixed
      */
     public static function get($routeName)
     {

--- a/var/Typecho/Router.php
+++ b/var/Typecho/Router.php
@@ -46,6 +46,7 @@ class Typecho_Router
      * @param string $pathInfo 全路径
      * @param mixed $parameter 输入参数
      * @return mixed
+     * @throws Exception
      */
     public static function match($pathInfo, $parameter = NULL)
     {
@@ -111,7 +112,7 @@ class Typecho_Router
      * 路由分发函数
      *
      * @return void
-     * @throws Typecho_Router_Exception
+     * @throws Exception
      */
     public static function dispatch()
     {

--- a/var/Typecho/Router/Parser.php
+++ b/var/Typecho/Router/Parser.php
@@ -48,7 +48,6 @@ class Typecho_Router_Parser
      *
      * @access public
      * @param array $routingTable 路由器映射表
-     * @return void
      */
     public function __construct(array $routingTable)
     {

--- a/var/Typecho/Widget.php
+++ b/var/Typecho/Widget.php
@@ -91,7 +91,7 @@ abstract class Typecho_Widget
      * config对象
      *
      * @access public
-     * @var public
+     * @var Typecho_Config
      */
     public $parameter;
 
@@ -102,7 +102,6 @@ abstract class Typecho_Widget
      * @param mixed $request request对象
      * @param mixed $response response对象
      * @param mixed $params 参数列表
-     * @return void
      */
     public function __construct($request, $response, $params = NULL)
     {
@@ -244,7 +243,7 @@ abstract class Typecho_Widget
      * 将类本身赋值
      *
      * @param string $variable 变量名
-     * @return void
+     * @return self
      */
     public function to(&$variable)
     {
@@ -285,7 +284,6 @@ abstract class Typecho_Widget
      * 根据余数输出
      *
      * @access public
-     * @param string $param 需要输出的值
      * @return void
      */
     public function alt()


### PR DESCRIPTION
更新一下 PHPDoc，主要改变了以下属性：
- @param
  + 修改 [Type] 参数错误。
  + 删除函数参数中不包含的。
- @return
  + 修改 [Type] 参数错误。
  + 删除构造函数的`@return`。 [constructors, the @return tag MAY be omitted here, in which case @return self is implied.](http://www.phpdoc.org/docs/latest/references/phpdoc/tags/return.html)

+ @var 根据下面的代码填了类型，修改了之前错误的写法。
+ @throws 两个函数都可能抛出`Exception`，都改成这个了。

刚开始看代码，慢慢看，顺便把 phpDoc 都改正确。