### PR TITLE
增加Mysqli适配器，修正一处可能引发 php fatal error的问题

### DIFF
--- a/admin/header.php
+++ b/admin/header.php
@@ -12,7 +12,7 @@ $header = '<link rel="stylesheet" href="' . Typecho_Common::url('normalize.css?v
 <![endif]-->';
 
 /** 注册一个初始化插件 */
-$header = Typecho_Plugin::factory('admin/header.php')->header($header);
+$header = $header . Typecho_Plugin::factory('admin/header.php')->header();
 
 ?><!DOCTYPE HTML>
 <html class="no-js">

--- a/var/Typecho/Common.php
+++ b/var/Typecho/Common.php
@@ -229,10 +229,10 @@ class Typecho_Common
      * 异常截获函数
      *
      * @access public
-     * @param Exception $exception 截获的异常
+     * @param $exception 截获的异常
      * @return void
      */
-    public static function exceptionHandle(Exception $exception)
+    public static function exceptionHandle($exception)
     {
         @ob_end_clean();
 

--- a/var/Typecho/Db/Adapter/Mysqli.php
+++ b/var/Typecho/Db/Adapter/Mysqli.php
@@ -1,0 +1,170 @@
+<?php
+if (!defined('__TYPECHO_ROOT_DIR__')) exit;
+/**
+ * Typecho Blog Platform
+ *
+ * @copyright  Copyright (c) 2008 Typecho team (http://www.typecho.org)
+ * @license    GNU General Public License 2.0
+ * @version    $Id: Mysqli.php 103 2015-12-09 16:22:43Z AtaLuZiK
+ */
+
+/**
+ * 数据库Mysqli适配器
+ *
+ * @package Db
+ */
+class Typecho_Db_Adapter_Mysqli implements Typecho_Db_Adapter
+{
+    /**
+     * 数据库连接字符串标示
+     *
+     * @access private
+     * @var resource
+     */
+    private $_dbLink;
+
+    /**
+     * 判断适配器是否可用
+     *
+     * @access public
+     * @return boolean
+     */
+    public static function isAvailable()
+    {
+        return function_exists('mysqli_connect');
+    }
+
+    /**
+     * 数据库连接函数
+     *
+     * @param Typecho_Config $config 数据库配置
+     * @throws Typecho_Db_Exception
+     * @return resource
+     */
+    public function connect(Typecho_Config $config)
+    {
+        if ($this->_dbLink = @mysqli_connect($config->host . (empty($config->port) ? '' : ':' . $config->port), $config->user, $config->password)) {
+            //if (@mysqli_select_db($config->database, $this->_dbLink)) {
+            if (@mysqli_select_db($this->_dbLink, $config->database)) {
+                if ($config->charset) {
+                    mysqli_query($this->_dbLink, "SET NAMES '{$config->charset}'");
+                }
+                return $this->_dbLink;
+            }
+        }
+        /** 数据库异常 */
+        throw new Typecho_Db_Adapter_Exception(@mysqli_error($this->_dbLink));
+    }
+
+    /**
+     * 执行数据库查询
+     *
+     * @param string $query 数据库查询SQL字符串
+     * @param mixed $handle 连接对象
+     * @param integer $op 数据库读写状态
+     * @param string $action 数据库动作
+     * @throws Typecho_Db_Exception
+     * @return resource
+     */
+    public function query($query, $handle, $op = Typecho_Db::READ, $action = NULL)
+    {
+        if ($resource = @mysqli_query($handle, $query instanceof Typecho_Db_Query ? $query->__toString() : $query)) {
+            return $resource;
+        }
+
+        /** 数据库异常 */
+        throw new Typecho_Db_Query_Exception(@mysqli_error($this->_dbLink), mysqli_errno($this->_dbLink));
+    }
+
+    /**
+     * 将数据查询的其中一行作为数组取出,其中字段名对应数组键值
+     *
+     * @param resource $resource 查询返回资源标识
+     * @return array
+     */
+    public function fetch($resource)
+    {
+        return mysqli_fetch_assoc($resource);
+    }
+
+    /**
+     * 将数据查询的其中一行作为对象取出,其中字段名对应对象属性
+     *
+     * @param resource $resource 查询的资源数据
+     * @return object
+     */
+    public function fetchObject($resource)
+    {
+        return mysqli_fetch_object($resource);
+    }
+
+    /**
+     * 引号转义函数
+     *
+     * @param string $string 需要转义的字符串
+     * @return string
+     */
+    public function quoteValue($string)
+    {
+        return '\'' . str_replace(array('\'', '\\'), array('\'\'', '\\\\'), $string) . '\'';
+    }
+
+    /**
+     * 对象引号过滤
+     *
+     * @access public
+     * @param string $string
+     * @return string
+     */
+    public function quoteColumn($string)
+    {
+        return '`' . $string . '`';
+    }
+
+    /**
+     * 合成查询语句
+     *
+     * @access public
+     * @param array $sql 查询对象词法数组
+     * @return string
+     */
+    public function parseSelect(array $sql)
+    {
+        if (!empty($sql['join'])) {
+            foreach ($sql['join'] as $val) {
+                list($table, $condition, $op) = $val;
+                $sql['table'] = "{$sql['table']} {$op} JOIN {$table} ON {$condition}";
+            }
+        }
+
+        $sql['limit'] = (0 == strlen($sql['limit'])) ? NULL : ' LIMIT ' . $sql['limit'];
+        $sql['offset'] = (0 == strlen($sql['offset'])) ? NULL : ' OFFSET ' . $sql['offset'];
+
+        return 'SELECT ' . $sql['fields'] . ' FROM ' . $sql['table'] .
+        $sql['where'] . $sql['group'] . $sql['having'] . $sql['order'] . $sql['limit'] . $sql['offset'];
+    }
+
+    /**
+     * 取出最后一次查询影响的行数
+     *
+     * @param resource $resource 查询的资源数据
+     * @param mixed $handle 连接对象
+     * @return integer
+     */
+    public function affectedRows($resource, $handle)
+    {
+        return mysqli_affected_rows($handle);
+    }
+
+    /**
+     * 取出最后一次插入返回的主键值
+     *
+     * @param resource $resource 查询的资源数据
+     * @param mixed $handle 连接对象
+     * @return integer
+     */
+    public function lastInsertId($resource, $handle)
+    {
+        return mysqli_insert_id($handle);
+    }
+}


### PR DESCRIPTION
1. 增加Mysqli适配器
2. 修复一处可能引发PHP Fatal Error的问题

2源自文件 var/Typecho/Common.php 第235行，形参$exception使用了类型类型声明，若（系统）抛出一个不是从Exception派生的异常，导致500错误且页面无任何信息。错误日志如下：

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Typecho_Common::exceptionHandle() must be an instance of Exception, instance of Error given in /var/Typecho/Common.php:235\nStack trace:\n#0 [internal function]: Typecho_Common::exceptionHandle(Object(Error))\n#1 {main}\n  thrown in /var/Typecho/Common.php on line 235
```