### PR TITLE
bugfix: In function 'treeViewCategoriesCallback' , the item Tag is hardcode w…

### DIFF
--- a/var/Widget/Metas/Category/List.php
+++ b/var/Widget/Metas/Category/List.php
@@ -179,7 +179,7 @@ class Widget_Metas_Category_List extends Widget_Abstract_Metas
             $this->treeViewCategories();
         }
 
-        echo '</li>';
+        echo '</' . $categoryOptions->itemTag . '>';
     }
 
     /**


### PR DESCRIPTION
…ith 'li' . It should be replaced by itemTag.