### PR TITLE
修复 iconv 函数参数传递错误

### DIFF
--- a/var/Typecho/Request.php
+++ b/var/Typecho/Request.php
@@ -601,7 +601,7 @@ class Typecho_Request
                 if (function_exists('mb_convert_encoding')) {
                     $pathInfo = mb_convert_encoding($pathInfo, $outputEncoding, $inputEncoding);
                 } else if (function_exists('iconv')) {
-                    $pathInfo = iconv($pathInfoEncoding, $outputEncoding, $pathInfo);
+                    $pathInfo = iconv($inputEncoding, $outputEncoding, $pathInfo);
                 }
             }
         } else {


### PR DESCRIPTION
之前的输入字符集写错了，弄了个不存在的变量。