### PR TITLE
修改默认主题搜索框右侧放大镜的样式

### DIFF
--- a/usr/themes/default/style.css
+++ b/usr/themes/default/style.css
@@ -161,7 +161,7 @@ textarea {
 #search button {
   position: absolute;
   right: 4px;
-  top: 2px;
+  top: 3.4px;
   border: none;
   padding: 0;
   width: 24px;


### PR DESCRIPTION
搜索框整体的高度是34px，放大镜图片高度是24px，因此放大镜图片top的值改成3.4px刚好使得居中