### PR TITLE
修正存在文章草稿时的页面跳转问题

### DIFF
--- a/var/Widget/Abstract/Contents.php
+++ b/var/Widget/Abstract/Contents.php
@@ -78,7 +78,7 @@ class Widget_Abstract_Contents extends Widget_Abstract
 
     /**
      * ___fields
-     * 
+     *
      * @access protected
      * @return Typecho_Config
      */
@@ -167,10 +167,10 @@ class Widget_Abstract_Contents extends Widget_Abstract
     {
         return $this->type . '-' . $this->cid;
     }
-    
+
     /**
      * 回复框id
-     * 
+     *
      * @access protected
      * @return string
      */
@@ -178,10 +178,10 @@ class Widget_Abstract_Contents extends Widget_Abstract
     {
         return 'respond-' . $this->theId;
     }
-    
+
     /**
      * 评论地址
-     * 
+     *
      * @access protected
      * @return string
      */
@@ -192,10 +192,10 @@ class Widget_Abstract_Contents extends Widget_Abstract
         return Typecho_Router::url('feedback',
             array('type' => 'comment', 'permalink' => $this->pathinfo), $this->options->index);
     }
-    
+
     /**
      * trackback地址
-     * 
+     *
      * @access protected
      * @return string
      */
@@ -204,10 +204,10 @@ class Widget_Abstract_Contents extends Widget_Abstract
         return Typecho_Router::url('feedback',
             array('type' => 'trackback', 'permalink' => $this->pathinfo), $this->options->index);
     }
-    
+
     /**
      * 回复地址
-     * 
+     *
      * @access protected
      * @return string
      */
@@ -233,6 +233,12 @@ class Widget_Abstract_Contents extends Widget_Abstract
         $select = $this->db->select(array('COUNT(table.contents.cid)' => 'num'))->from('table.contents')
         ->where("table.contents.{$column} > {$offset}")
         ->where("table.contents.type = ?", $type);
+
+        if ($type === "post") {    //修正当有文章草稿时的跳转位置
+          $select = $this->db->select(array('COUNT(DISTINCT table.contents.title)' => 'num'))->from('table.contents')
+          ->where("table.contents.{$column} > {$offset}")
+          ->Where("type = 'post' or type = 'post_draft'");
+        }
 
         if (!empty($status)) {
             $select->where("table.contents.status = ?", $status);
@@ -415,8 +421,8 @@ class Widget_Abstract_Contents extends Widget_Abstract
 
     /**
      * 删除自定义字段
-     * 
-     * @param integer $cid 
+     *
+     * @param integer $cid
      * @access public
      * @return integer
      */
@@ -427,9 +433,9 @@ class Widget_Abstract_Contents extends Widget_Abstract
     }
 
     /**
-     * 检查字段名是否符合要求  
-     * 
-     * @param string $name 
+     * 检查字段名是否符合要求
+     *
+     * @param string $name
      * @access public
      * @return boolean
      */
@@ -439,10 +445,10 @@ class Widget_Abstract_Contents extends Widget_Abstract
     }
 
     /**
-     * 保存自定义字段 
-     * 
-     * @param array $fields 
-     * @param mixed $cid 
+     * 保存自定义字段
+     *
+     * @param array $fields
+     * @param mixed $cid
      * @access public
      * @return void
      */
@@ -473,7 +479,7 @@ class Widget_Abstract_Contents extends Widget_Abstract
             if (isset($exists[$name])) {
                 unset($exists[$name]);
             }
- 
+
             $this->setField($name, $type, $value, $cid);
         }
 
@@ -485,17 +491,17 @@ class Widget_Abstract_Contents extends Widget_Abstract
 
     /**
      * 设置单个字段
-     * 
-     * @param string $name 
-     * @param string $type 
-     * @param string $value 
-     * @param integer $cid 
+     *
+     * @param string $name
+     * @param string $type
+     * @param string $value
+     * @param integer $cid
      * @access public
      * @return integer
      */
     public function setField($name, $type, $value, $cid)
     {
-        if (empty($name) || !$this->checkFieldName($name) 
+        if (empty($name) || !$this->checkFieldName($name)
             || !in_array($type, array('str', 'int', 'float'))) {
             return false;
         }
@@ -527,10 +533,10 @@ class Widget_Abstract_Contents extends Widget_Abstract
 
     /**
      * 自增一个整形字段
-     * 
-     * @param string $name 
-     * @param integer $value 
-     * @param integer $cid 
+     *
+     * @param string $name
+     * @param integer $value
+     * @param integer $cid
      * @access public
      * @return integer
      */
@@ -598,7 +604,7 @@ class Widget_Abstract_Contents extends Widget_Abstract
             ->from('table.contents')
             ->cleanAttribute('group'))->num;
     }
-    
+
     /**
      * 获取当前所有自定义模板
      *
@@ -716,11 +722,11 @@ class Widget_Abstract_Contents extends Widget_Abstract
         $value['slug'] = $tmpSlug;
         $value['category'] = $tmpCategory;
         $value['directory'] = $tmpDirectory;
-        
+
         /** 处理密码保护流程 */
         if (!empty($value['password']) &&
         $value['password'] !== Typecho_Cookie::get('protectPassword') &&
-        $value['authorId'] != $this->user->uid && 
+        $value['authorId'] != $this->user->uid &&
         !$this->user->pass('editor', true)) {
             $value['hidden'] = true;
 
@@ -926,9 +932,9 @@ class Widget_Abstract_Contents extends Widget_Abstract
     }
 
     /**
-     * autoP 
-     * 
-     * @param mixed $text 
+     * autoP
+     *
+     * @param mixed $text
      * @access public
      * @return void
      */
@@ -950,9 +956,9 @@ class Widget_Abstract_Contents extends Widget_Abstract
     }
 
     /**
-     * markdown  
-     * 
-     * @param mixed $text 
+     * markdown
+     *
+     * @param mixed $text
      * @access public
      * @return void
      */
@@ -967,4 +973,3 @@ class Widget_Abstract_Contents extends Widget_Abstract
         return $html;
     }
 }
-


### PR DESCRIPTION
之前当存在尚未发布的文章草稿时，编辑其他文章并点击“发布内容后”，会出现跳转页码上的偏差
碧如原本是在第二页的文章，点击完发布后会跳转到第一页

修改后修正了这个问题