### PR TITLE
修复某些环境下当标签为中文时产生垃圾链接。

### DIFF
--- a/var/Typecho/Request.php
+++ b/var/Typecho/Request.php
@@ -479,10 +479,10 @@ class Typecho_Request
 
         if (isset($_SERVER['SCRIPT_NAME']) && basename($_SERVER['SCRIPT_NAME']) === $filename) {
             $baseUrl = $_SERVER['SCRIPT_NAME'];
-        } elseif (isset($_SERVER['PHP_SELF']) && basename($_SERVER['PHP_SELF']) === $filename) {
-            $baseUrl = $_SERVER['PHP_SELF'];
         } elseif (isset($_SERVER['ORIG_SCRIPT_NAME']) && basename($_SERVER['ORIG_SCRIPT_NAME']) === $filename) {
             $baseUrl = $_SERVER['ORIG_SCRIPT_NAME']; // 1and1 shared hosting compatibility
+        } elseif (isset($_SERVER['PHP_SELF']) && basename($_SERVER['PHP_SELF']) === $filename) {
+            $baseUrl = $_SERVER['PHP_SELF'];
         } else {
             // Backtrack up the script_filename to find the portion matching
             // php_self


### PR DESCRIPTION
https://ghostcir.com/1.png
https://ghostcir.com/2.png
https://ghostcir.com/3.png
我也不清楚这样修复会产生什么结果。。。还望见谅，
我的环境是nginx1.11.6   php-fpm-7.0.14