### PR TITLE
修复聚合调用时的判断问题

### DIFF
--- a/var/Widget/Archive.php
+++ b/var/Widget/Archive.php
@@ -1227,7 +1227,7 @@ class Widget_Archive extends Widget_Abstract_Contents
      */
     public function select()
     {
-        if ($this->_feed) {
+        if ($this->_invokeByFeed) {
             // 对feed输出加入限制条件
             return parent::select()->where('table.contents.allowFeed = ?', 1)
             ->where('table.contents.password IS NULL');


### PR DESCRIPTION
发布文章时，去掉"高级选项"->"权限控制"->"允许在聚合中出现", 却依然能在rss中看见。后来发现可能时那个判断的问题