### PR TITLE
fix: Mysqli quoteColumn 函数参数调用错误

### DIFF
--- a/var/Typecho/Db/Adapter/Mysqli.php
+++ b/var/Typecho/Db/Adapter/Mysqli.php
@@ -128,7 +128,7 @@ class Typecho_Db_Adapter_Mysqli implements Typecho_Db_Adapter
      */
     public function quoteColumn($string)
     {
-        return $resource->real_escape_string($string);
+        return $this->_dbLink->real_escape_string($string);
     }
 
     /**


### PR DESCRIPTION
现有的写错了，这个函数里面没有 resource 变量。
参见 http://php.net/manual/zh/mysqli.real-escape-string.php