### PR TITLE
修复主题编辑下模板文件某些情况不显示的问题

### DIFF
--- a/var/Widget/Themes/Files.php
+++ b/var/Widget/Themes/Files.php
@@ -53,7 +53,11 @@ class Widget_Themes_Files extends Typecho_Widget
         if (preg_match("/^([_0-9a-z-\.\ ])+$/i", $this->_currentTheme)
             && is_dir($dir = $this->widget('Widget_Options')->themeFile($this->_currentTheme))
             && (!defined('__TYPECHO_THEME_WRITEABLE__') || __TYPECHO_THEME_WRITEABLE__)) {
-            $files = glob($dir . '/*.{php,PHP,js,JS,css,CSS,vbs,VBS}', GLOB_BRACE);
+            $items = array('php', 'PHP', 'js', 'JS', 'css', 'CSS', 'vbs', 'VBS');
+            $files = array();
+            foreach ($items as $item) {
+                $files = array_merge($files, glob($dir . '/*.' . $item));
+            }
             $this->_currentFile = $this->request->get('file', 'index.php');
 
             if (preg_match("/^([_0-9a-z-\.\ ])+$/i", $this->_currentFile)

--- a/var/Widget/Themes/List.php
+++ b/var/Widget/Themes/List.php
@@ -68,7 +68,11 @@ class Widget_Themes_List extends Typecho_Widget
                         $activated = $key;
                     }
 
-                    $screen = glob($theme . '/screen*.{jpg,png,gif,bmp,jpeg,JPG,PNG,GIF,BMG,JPEG}', GLOB_BRACE);
+                    $items = array('jpg', 'png', 'gif', 'bmp', 'jpeg', 'JPG', 'PNG', 'GIF', 'BMG', 'JPEG');
+                    $screen = array();
+                    foreach ($items as $item) {
+                        $screen = array_merge($screen, glob($theme . '/*.' . $item));
+                    }
                     if ($screen) {
                         $info['screen'] = $options->themeUrl(basename(current($screen)), $info['name']);
                     } else {


### PR DESCRIPTION
我使用 Docker 构建 Caddy(with php) 后, 运行 typecho 在主题编辑下模板文件列表不显示.

查看日志后发现了几个错误:

>2017-04-16 17:03:11:120.236.163.105 - [16/Apr/2017:09:00:06 +0000] "GET /admin/themes.php HTTP/1.1" 200 3270
2017-04-16 17:03:11:16/Apr/2017:09:00:09 +0000 [ERROR 0 /admin/theme-editor.php] PHP message: PHP Notice:  Use of undefined constant GLOB_BRACE - assumed 'GLOB_BRACE' in /srv/var/Widget/Themes/Files.php on line 56
2017-04-16 17:03:11:PHP message: PHP Warning:  glob() expects parameter 2 to be integer, string given in /srv/var/Widget/Themes/Files.php on line 56
2017-04-16 17:03:11:PHP message: PHP Warning:  Invalid argument supplied for foreach() in /srv/var/Widget/Themes/Files.php on line 61
2017-04-16 17:03:11:120.236.163.105 - [16/Apr/2017:09:00:09 +0000] "GET /admin/theme-editor.php HTTP/1.1" 200 3611

第一个错误是因为 `GLOB_BRACE` 并不适合全部系统，我构建的 Caddy 是基于 `alpine:3.5` 镜像的，可能因为这个原因所以这个东西没法使用．所以我改成了另一种方式．
第二个错误我把 `foreach ($files as $file) ` 改为 `foreach ((array) $files as $file) ` 就好了．

这样修改后就使用正常了，并且我在自己虚拟主机上也如上修改后功能也仍然可以正常使用