### PR TITLE
修复li标签中生成p标签的bug

### DIFF
--- a/admin/js/hyperdown.js
+++ b/admin/js/hyperdown.js
@@ -851,7 +851,7 @@
       if (str.match(/^\s*$/)) {
         return '';
       } else {
-        return "<p>" + str + "</p>";
+        return str.match(/^(.*)<\/p><p>(.*)$/) ? "<p>" + str + "</p>" : str;
       }
     };
 

--- a/var/HyperDown.php
+++ b/var/HyperDown.php
@@ -1133,7 +1133,7 @@ class HyperDown
         $str = preg_replace("/(\n\s*){2,}/", "</p><p>", $str);
         $str = preg_replace("/\n/", "<br>", $str);
 
-        return preg_match("/^\s*$/", $str) ? '' : "<p>{$str}</p>";
+        return preg_match("/^\s*$/", $str) ? '' : (stripos($str, '</p><p>') ? "<p>{$str}</p>" : $str);
     }
 
     /**


### PR DESCRIPTION
**eg**
```
 - item1
 - item2
 - item3
```

**Before**
```
<ul>
  <li><p>item1</p></li>
  <li><p>item2</p></li>
  <li><p>item3</p></li>
</ul>
```

**After**:
```
<ul>
  <li>item1</li>
  <li>item2</li>
  <li>item3</li>
</ul>
```
