### PR TITLE
Fix X-UA-Compatible

### DIFF
--- a/admin/header.php
+++ b/admin/header.php
@@ -18,7 +18,7 @@ $header = Typecho_Plugin::factory('admin/header.php')->header($header);
 <html class="no-js">
     <head>
         <meta charset="<?php $options->charset(); ?>">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="renderer" content="webkit">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title><?php _e('%s - %s - Powered by Typecho', $menu->title, $options->title); ?></title>


### PR DESCRIPTION
`chrome=1`已不再使用。详见<https://stackoverflow.com/questions/22059060/is-it-still-valid-to-use-ie-edge-chrome-1>。