### PR TITLE
主题缩略图使用screenshot命名的图片

### DIFF
--- a/var/Widget/Themes/List.php
+++ b/var/Widget/Themes/List.php
@@ -69,7 +69,7 @@ class Widget_Themes_List extends Typecho_Widget
                     }
 
                     $screen = array_filter(glob($theme . '/*'), function ($path) {
-                        return preg_match("/\.(jpg|png|gif|bmp|jpeg)$/i", $path);
+                        return preg_match("/screenshot\.(jpg|png|gif|bmp|jpeg)$/i", $path);
                     });
 
                     if ($screen) {


### PR DESCRIPTION
修复主题根目录存在screenshot.png和其他图片时，主题展示图抓取其他图片的问题