### PR TITLE
update normalize.css for admin panel and default theme

### DIFF
--- a/usr/themes/default/header.php
+++ b/usr/themes/default/header.php
@@ -14,7 +14,7 @@
         ), '', ' - '); ?><?php $this->options->title(); ?></title>
 
     <!-- 使用url函数转换相关路径 -->
-    <link rel="stylesheet" href="//cdnjscn.b0.upaiyun.com/libs/normalize/2.1.3/normalize.min.css">
+    <link rel="stylesheet" href="<?php $this->options->themeUrl('normalize.css'); ?>">
     <link rel="stylesheet" href="<?php $this->options->themeUrl('grid.css'); ?>">
     <link rel="stylesheet" href="<?php $this->options->themeUrl('style.css'); ?>">
 

--- a/usr/themes/default/normalize.css
+++ b/usr/themes/default/normalize.css
@@ -8,7 +8,7 @@
  * 2. Prevent adjustments of font size after orientation changes in iOS.
  */
 
-html {
+ html {
   line-height: 1.15; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
 }


### PR DESCRIPTION
default theme 的 normalize.css 外部 CDN 链接已经失效很久了，顺带 admin panel 的最好也更新一下吧
最新版本官方发布链接如下
[https://necolas.github.io/normalize.css/latest/normalize.css](https://necolas.github.io/normalize.css/latest/normalize.css)

但是考虑到网络连接、外部CDN失效等问题，作为本地文件和 grid.css 一样可能更合适一点