### PR TITLE
fix Typecho_Common::removeXSS

### DIFF
--- a/var/Typecho/Common.php
+++ b/var/Typecho/Common.php
@@ -684,60 +684,66 @@ EOF;
      */
     public static function removeXSS($val)
     {
-       // remove all non-printable characters. CR(0a) and LF(0b) and TAB(9) are allowed
-       // this prevents some character re-spacing such as <java\0script>
-       // note that you have to handle splits with \n, \r, and \t later since they *are* allowed in some inputs
-       $val = preg_replace('/([\x00-\x08]|[\x0b-\x0c]|[\x0e-\x19])/', '', $val);
+        // remove all non-printable characters. CR(0a) and LF(0b) and TAB(9) are allowed
+        // this prevents some character re-spacing such as <java\0script>
+        // note that you have to handle splits with \n, \r, and \t later since they *are* allowed in some inputs
+        $val = preg_replace('/([\x00-\x08]|[\x0b-\x0c]|[\x0e-\x19])/', '', $val);
 
-       // straight replacements, the user should never need these since they're normal characters
-       // this prevents like <IMG SRC=&#X40&#X61&#X76&#X61&#X73&#X63&#X72&#X69&#X70&#X74&#X3A&#X61&#X6C&#X65&#X72&#X74&#X28&#X27&#X58&#X53&#X53&#X27&#X29>
-       $search = 'abcdefghijklmnopqrstuvwxyz';
-       $search .= 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-       $search .= '1234567890!@#$%^&*()';
-       $search .= '~`";:?+/={}[]-_|\'\\';
+        // straight replacements, the user should never need these since they're normal characters
+        // this prevents like <IMG SRC=&#X40&#X61&#X76&#X61&#X73&#X63&#X72&#X69&#X70&#X74&#X3A&#X61&#X6C&#X65&#X72&#X74&#X28&#X27&#X58&#X53&#X53&#X27&#X29>
+        $search = 'abcdefghijklmnopqrstuvwxyz';
+        $search .= 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        $search .= '1234567890!@#$%^&*()';
+        $search .= '~`";:?+/={}[]-_|\'\\';
 
-       for ($i = 0; $i < strlen($search); $i++) {
-          // ;? matches the ;, which is optional
-          // 0{0,7} matches any padded zeros, which are optional and go up to 8 chars
+        $valChanged = true;
+        while ($valChanged) {
+            for ($i = 0; $i < strlen($search); $i++) {
+                // ;? matches the ;, which is optional
+                // 0{0,7} matches any padded zeros, which are optional and go up to 8 chars
 
-          // &#x0040 @ search for the hex values
-          $val = preg_replace('/(&#[xX]0{0,8}'.dechex(ord($search[$i])).';?)/i', $search[$i], $val); // with a ;
-          // &#00064 @ 0{0,7} matches '0' zero to seven times
-          $val = preg_replace('/(&#0{0,8}'.ord($search[$i]).';?)/', $search[$i], $val); // with a ;
-       }
+                // &#x0040 @ search for the hex values
+                $newVal = preg_replace('/(&#[xX]0{0,8}'.dechex(ord($search[$i])).';?)/i', $search[$i], $val); // with a ;
+                // &#00064 @ 0{0,7} matches '0' zero to seven times
+                $newVal = preg_replace('/(&#0{0,8}'.ord($search[$i]).';?)/', $search[$i], $newVal);// with a ;
+            }
 
-       // now the only remaining whitespace attacks are \t, \n, and \r
-       $ra1 = Array('javascript', 'vbscript', 'expression', 'applet', 'meta', 'xml', 'blink', 'link', 'style', 'script', 'embed', 'object', 'iframe', 'frame', 'frameset', 'ilayer', 'layer', 'bgsound', 'title', 'base');
-       $ra2 = Array('onabort', 'onactivate', 'onafterprint', 'onafterupdate', 'onbeforeactivate', 'onbeforecopy', 'onbeforecut', 'onbeforedeactivate', 'onbeforeeditfocus', 'onbeforepaste', 'onbeforeprint', 'onbeforeunload', 'onbeforeupdate', 'onblur', 'onbounce', 'oncellchange', 'onchange', 'onclick', 'oncontextmenu', 'oncontrolselect', 'oncopy', 'oncut', 'ondataavailable', 'ondatasetchanged', 'ondatasetcomplete', 'ondblclick', 'ondeactivate', 'ondrag', 'ondragend', 'ondragenter', 'ondragleave', 'ondragover', 'ondragstart', 'ondrop', 'onerror', 'onerrorupdate', 'onfilterchange', 'onfinish', 'onfocus', 'onfocusin', 'onfocusout', 'onhelp', 'onkeydown', 'onkeypress', 'onkeyup', 'onlayoutcomplete', 'onload', 'onlosecapture', 'onmousedown', 'onmouseenter', 'onmouseleave', 'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup', 'onmousewheel', 'onmove', 'onmoveend', 'onmovestart', 'onpaste', 'onpropertychange', 'onreadystatechange', 'onreset', 'onresize', 'onresizeend', 'onresizestart', 'onrowenter', 'onrowexit', 'onrowsdelete', 'onrowsinserted', 'onscroll', 'onselect', 'onselectionchange', 'onselectstart', 'onstart', 'onstop', 'onsubmit', 'onunload');
-       $ra = array_merge($ra1, $ra2);
+            $valChanged = !($val == $newVal);
+            $val = $newVal;
+        }
 
-       $found = true; // keep replacing as long as the previous round replaced something
-       while ($found == true) {
-          $val_before = $val;
-          for ($i = 0; $i < sizeof($ra); $i++) {
-             $pattern = '/';
-             for ($j = 0; $j < strlen($ra[$i]); $j++) {
-                if ($j > 0) {
-                   $pattern .= '(';
-                   $pattern .= '(&#[xX]0{0,8}([9ab]);)';
-                   $pattern .= '|';
-                   $pattern .= '|(&#0{0,8}([9|10|13]);)';
-                   $pattern .= ')*';
+        // now the only remaining whitespace attacks are \t, \n, and \r
+        $ra1 = Array('javascript', 'vbscript', 'expression', 'applet', 'meta', 'xml', 'blink', 'link', 'style', 'script', 'embed', 'object', 'iframe', 'frame', 'frameset', 'ilayer', 'layer', 'bgsound', 'title', 'base');
+        $ra2 = Array('onabort', 'onactivate', 'onafterprint', 'onafterupdate', 'onbeforeactivate', 'onbeforecopy', 'onbeforecut', 'onbeforedeactivate', 'onbeforeeditfocus', 'onbeforepaste', 'onbeforeprint', 'onbeforeunload', 'onbeforeupdate', 'onblur', 'onbounce', 'oncellchange', 'onchange', 'onclick', 'oncontextmenu', 'oncontrolselect', 'oncopy', 'oncut', 'ondataavailable', 'ondatasetchanged', 'ondatasetcomplete', 'ondblclick', 'ondeactivate', 'ondrag', 'ondragend', 'ondragenter', 'ondragleave', 'ondragover', 'ondragstart', 'ondrop', 'onerror', 'onerrorupdate', 'onfilterchange', 'onfinish', 'onfocus', 'onfocusin', 'onfocusout', 'onhelp', 'onkeydown', 'onkeypress', 'onkeyup', 'onlayoutcomplete', 'onload', 'onlosecapture', 'onmousedown', 'onmouseenter', 'onmouseleave', 'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup', 'onmousewheel', 'onmove', 'onmoveend', 'onmovestart', 'onpaste', 'onpropertychange', 'onreadystatechange', 'onreset', 'onresize', 'onresizeend', 'onresizestart', 'onrowenter', 'onrowexit', 'onrowsdelete', 'onrowsinserted', 'onscroll', 'onselect', 'onselectionchange', 'onselectstart', 'onstart', 'onstop', 'onsubmit', 'onunload');
+        $ra = array_merge($ra1, $ra2);
+
+        $found = true; // keep replacing as long as the previous round replaced something
+        while ($found == true) {
+            $valBefore = $val;
+            for ($i = 0; $i < sizeof($ra); $i++) {
+                $pattern = '/';
+                for ($j = 0; $j < strlen($ra[$i]); $j++) {
+                    if ($j > 0) {
+                    $pattern .= '(';
+                    $pattern .= '(&#[xX]0{0,8}([9ab]);?)';
+                    $pattern .= '|';
+                    $pattern .= '|(&#0{0,8}([9|10|13]);?)';
+                    $pattern .= ')*';
+                    }
+                    $pattern .= $ra[$i][$j];
                 }
-                $pattern .= $ra[$i][$j];
-             }
-             $pattern .= '/i';
-             $replacement = substr($ra[$i], 0, 2).'<x>'.substr($ra[$i], 2); // add in <> to nerf the tag
-             $val = preg_replace($pattern, $replacement, $val); // filter out the hex tags
+                $pattern .= '/i';
+                $replacement = substr($ra[$i], 0, 2).'<x>'.substr($ra[$i], 2); // add in <> to nerf the tag
+                $val = preg_replace($pattern, $replacement, $val); // filter out the hex tags
 
-             if ($val_before == $val) {
-                // no replacements were made, so exit the loop
-                $found = false;
-             }
-          }
-       }
+                if ($valBefore == $val) {
+                    // no replacements were made, so exit the loop
+                    $found = false;
+                }
+            }
+        }
 
-       return $val;
+        return $val;
     }
 
     /**


### PR DESCRIPTION
- 未达到预期过滤效果
（主要原因是第一步的编码替换操作未考虑嵌套的情形，见后面的对比）
- 原缩进为三个空格修正了下（所以大片diff）
- $val_before改为驼峰风格（[Typecho PHP 编码规范](http://docs.typecho.org/phpcoding)）
- 暂未发现会导致可利用的XSS安全问题

这段代码单独拧出来测试的，测试数据（[get_payload.py](https://github.com/mierhuo/StudyProgramming/blob/master/get_payload.py)）如下：

```php
echo removeXSS("&#&#514&#&#512&#&#4911&#&#4910&#&#4908&#&#4911&#&#577&#&#4900&#&#541&#&#4906&#&#577&#&#4918&#&#577&#&#4915&#&#579&#&#4914&#&#4905&#&#4912&#&#4916&#&#538&#&#577&#&#4908&#&#4901&#&#4914&#&#4916&#&#520&#&#514&#&#568&#&#563&#&#563&#&#514&#&#521");
```

修改前结果：

```
"&#32&#111&#110&#108&#111&#97&#100=&#106&#97&#118&#97&#115&#99&#114&#105&#112&#116:&#97&#108&#101&#114&#116("&#88&#83&#83")&#11#11

即：" onload=javascript:alert("XSS")
```

修改后结果：

```
&#&#514&#&#512&#&#4911&#&#4910&#&#4908&#&#4911&#&#577&#&#4900&#&#541&#&#4906&#&#577&#&#4918&#&#577&#&#4915&#&#579&#&#4914&#&#4905&#&#4912&#&#4916&#&#538&#&#577&#&#4908&#&#4901&#&#4914&#&#4916&#&#520&#&#514&#&#568&#&#563&#&#563&#&#514&#&#521#521

即：&#Ȃ&#Ȁ&#ጯ&#ጮ&#ጬ&#ጯ&#Ɂ&#ጤ&#ȝ&#ጪ&#Ɂ&#ጶ&#Ɂ&#ጳ&#Ƀ&#ጲ&#ጩ&#ጰ&#ጴ&#Ț&#Ɂ&#ጬ&#ጥ&#ጲ&#ጴ&#Ȉ&#Ȃ&#ȸ&#ȳ&#ȳ&#Ȃ&#ȉ
```

可见，修改后达到了预期效果。
