### PR TITLE
修复备份数据的 bug

### DIFF
--- a/var/Widget/Backup.php
+++ b/var/Widget/Backup.php
@@ -280,7 +280,7 @@ class Widget_Backup extends Widget_Abstract_Options implements Widget_Interface_
                 foreach ($rows as $row) {
                     $buffer .= $this->buildBuffer($val, $this->applyFields($type, $row));
 
-                    if (sizeof($buffer) >= 1024 * 1024) {
+                    if (strlen($buffer) >= 1024 * 1024) {
                         echo $buffer;
                         ob_flush();
                         $buffer = '';


### PR DESCRIPTION
> PHP Warning:  sizeof(): Parameter must be an array or an object that implements Countable

在执行数据备份时 sizeof() 函数的错误会导致 if (sizeof($buffer) >= 1024 * 1024) 一直为 false，失去缓存分段 flush 的目的。
这导致如果数据比较大的时候是一次性 flush，并且在开启显示 PHP Warning 的时候会同时将警告提示信息也写入备份文件，直接导致在恢复数据时提示：备份文件格式错误。