### PR TITLE
修复一处逻辑问题

### DIFF
--- a/admin/manage-posts.php
+++ b/admin/manage-posts.php
@@ -5,7 +5,7 @@ include 'menu.php';
 
 $stat = Typecho_Widget::widget('Widget_Stat');
 $posts = Typecho_Widget::widget('Widget_Contents_Post_Admin');
-$isAllPosts = ('on' == $request->get('__typecho_all_posts') || 'on' == Typecho_Cookie::get('__typecho_all_posts'));
+$isAllPosts = ('on' == $request->get('__typecho_all_posts') || ('off' != Typecho_Cookie::get('__typecho_all_posts') && 'off' != $request->get('__typecho_all_posts')));
 ?>
 <div class="main">
     <div class="body container">

--- a/var/Widget/Contents/Post/Admin.php
+++ b/var/Widget/Contents/Post/Admin.php
@@ -132,9 +132,10 @@ class Widget_Contents_Post_Admin extends Widget_Abstract_Contents
                     Typecho_Cookie::set('__typecho_all_posts', 'off');
                 }
 
-                if ('on' != Typecho_Cookie::get('__typecho_all_posts')) {
-                    $select->where('table.contents.authorId = ?', isset($this->request->uid) ?
-                        $this->request->filter('int')->uid : $this->user->uid);
+                if (isset($this->request->uid)) {
+                    $select->where('table.contents.authorId = ?', $this->request->filter('int')->uid);
+                } else if('off' == $this->request->__typecho_all_posts || 'off' == Typecho_Cookie::get('__typecho_all_posts')) {
+                    $select->where('table.contents.authorId = ?', $this->user->uid);
                 }
             }
         }


### PR DESCRIPTION
当前的逻辑存在两个问题：
1. 当客户端没有种下 cookie：`__typecho_all_posts` 时，显示的是 **我的** 文章，这或许不是问题（本来就是这样设计的），但常规逻辑一般是显示所有文章；
2. 当点击 **所有** 显示所有的文章，这时候就种下了 cookie：`__typecho_all_posts = on`，此时如果点击某个作者会一直显示所有的文章，这应该不符合常规逻辑，且待审核和草稿的气泡数量和实际显示的数量不符（气泡显示的数量是该作者的，列出的数量是所有的），通过 cookie 来保存客户端设置，当查看某个作者的文章不应该受此 cookie 设置的影响。

也许由于大部分人都是单用户，所以没什么影响。