### PR TITLE
improve comment XSS attack protection

### DIFF
--- a/var/Typecho/Common.php
+++ b/var/Typecho/Common.php
@@ -154,7 +154,9 @@ class Typecho_Common
 
         foreach ($attrs as $key => $val) {
             if (in_array($key, self::$_allowableAttributes[$tag])) {
-                $parsedAttrs[] = " {$key}" . (empty($val) ? '' : "={$val}");
+                if ($key !== 'href' || Typecho_Validate::url(substr($val, 1, -1))) {
+                    $parsedAttrs[] = " {$key}" . (empty($val) ? '' : "={$val}");
+                }
             }
         }
 


### PR DESCRIPTION
评论内容区域可在后台自定义配置允许的HTML标签与其属性，但是基本未对属性内容作任何保护。后台该输入框提示如下：

> 默认的用户评论不允许填写任何的HTML标签, 你可以在这里填写允许使用的HTML标签.
比如: `<a href=""> <img src=""> <blockquote>`

如果用户按照提示填入 `<a href="">` 则评论如下内容，即会导致问题：

```
<a href="javascript:alert('xss')">XSS Test</a>
``` 

在文章后的**评论显示区域**及后台管理界面中的**管理 - 评论界面**，都会产生问题。

鉴于常用的几个标签里面只有 `href` 属性会导致这个问题，且不考虑类似主动开放 `<script>` 标签的行为，应当对其进行防御。根据 `Typecho_Common::__parseAttrs()` 的解析流程及边界情况，只需要利用 `Typecho_Validate::url()` 对去掉包裹的引号的属性值进行判定即可，这样也禁掉了其他方式可能会被采用 Unicode 字符编码绕过的问题，而正常用户不会以字符编码形式输入所以无影响。

感觉允许评论区域插入链接的老哥应该还是不少的...