### PR TITLE
修正编辑器预览界面代码不自动换行问题

### DIFF
--- a/admin/css/style.css
+++ b/admin/css/style.css
@@ -1743,8 +1743,9 @@ a.operate-reply {
     padding: 1em; }
     /* line 125, ../scss/components/_editor.scss */
     #wmd-preview pre code {
-      padding: 0;
-      color: #444; }
+    padding: 0;
+    color: #444;
+    white-space: pre-wrap;}
   /* line 130, ../scss/components/_editor.scss */
   #wmd-preview blockquote {
     margin: 1em 1.5em;


### PR DESCRIPTION
编辑器预览界面，代码太长而没有换行会戳出屏幕外，故修复下，让其自动换行