### PR TITLE
fix #752

### DIFF
--- a/var/Widget/Contents/Post/Edit.php
+++ b/var/Widget/Contents/Post/Edit.php
@@ -257,8 +257,9 @@ class Widget_Contents_Post_Edit extends Widget_Abstract_Contents implements Widg
 
             /** 如果它本身不是草稿, 需要删除其草稿 */
             if (!$isDraftToPublish && $this->draft) {
-                $this->deleteDraft($this->draft['cid']);
-                $this->deleteFields($this->draft['cid']);
+                $cid = $this->draft['cid'];
+                $this->deleteDraft($cid);
+                $this->deleteFields($cid);
             }
 
             /** 直接将草稿状态更改 */


### PR DESCRIPTION
···php
260: $this->deleteDraft($this->draft['cid']);
261: $this->deleteFields($this->draft['cid']);
```

当执行260行之后，draft记录已经被删，所以当261行在执行的时候`$this->draft['cid']`为空。
修改方案为利用临时变量将draft['cid']保存下来。
