### PR TITLE
修正错误的数据堆栈

### DIFF
--- a/var/Widget/Comments/Archive.php
+++ b/var/Widget/Comments/Archive.php
@@ -282,7 +282,8 @@ class Widget_Comments_Archive extends Widget_Abstract_Comments
                 ($this->_currentPage - 1) * $this->options->commentsPageSize, $this->options->commentsPageSize);
             
             /** 评论置位 */
-            $this->row = current($this->stack);
+            if ($this->_total !== 0)
+                $this->row = current($this->stack);
             $this->length = count($this->stack);
         }
         

--- a/var/Widget/Comments/Archive.php
+++ b/var/Widget/Comments/Archive.php
@@ -282,10 +282,10 @@ class Widget_Comments_Archive extends Widget_Abstract_Comments
                 ($this->_currentPage - 1) * $this->options->commentsPageSize, $this->options->commentsPageSize);
             
             /** 评论置位 */
-            if (0 !== count($this->stack)) {
+            $this->length = count($this->stack);
+            if (0 !== $this->length) {
                 $this->row = current($this->stack);
             }
-            $this->length = count($this->stack);
         }
         
         reset($this->stack);

--- a/var/Widget/Comments/Archive.php
+++ b/var/Widget/Comments/Archive.php
@@ -282,8 +282,9 @@ class Widget_Comments_Archive extends Widget_Abstract_Comments
                 ($this->_currentPage - 1) * $this->options->commentsPageSize, $this->options->commentsPageSize);
             
             /** 评论置位 */
-            if ($this->_total !== 0)
+            if (0 !== count($this->stack)) {
                 $this->row = current($this->stack);
+            }
             $this->length = count($this->stack);
         }
         


### PR DESCRIPTION
在没有评论且开启评论分页的情况下，`$this->row` 会被错误地赋值为 `(boolean) false`，在之后通过魔术方法 `__get` 获取内部变量时会抛出警告，PHP `current()` 的文档中有提到这一点

> 如果内部指针指向超出了单元列表的末端，current() 返回 FALSE。

https://github.com/typecho/typecho/blob/a2d21f1042de56b3e069f9c0f0988eba44eb6a3e/var/Widget/Comments/Archive.php#L284-L285

![default](https://user-images.githubusercontent.com/18070833/43054657-302bc902-8e65-11e8-8c76-c97eb469a42f.png)