### PR TITLE
fix: Support plus in email address

### DIFF
--- a/var/Typecho/Validate.php
+++ b/var/Typecho/Validate.php
@@ -209,7 +209,7 @@ class Typecho_Validate
      */
     public static function email($str)
     {
-        return preg_match("/^[_a-z0-9-\.]+@([-a-z0-9]+\.)+[a-z]{2,}$/i", $str);
+        return preg_match("/^[_a-z0-9-\.+]+@([-a-z0-9]+\.)+[a-z]{2,}$/i", $str);
     }
 
     /**


### PR DESCRIPTION
fix: add support in email address (just like example+typecho@gmail.com)

Linked: #779 