### PR TITLE
解决插件注入右上角导航会有两个 | | 出现

### DIFF
--- a/admin/menu.php
+++ b/admin/menu.php
@@ -4,8 +4,7 @@
         <?php $menu->output(); ?>
     </nav>
     <div class="operate">
-        <?php Typecho_Plugin::factory('admin/menu.php')->navBar(); ?>
-        <a title="<?php
+        <?php Typecho_Plugin::factory('admin/menu.php')->navBar(); ?><a title="<?php
                     if ($user->logged > 0) {
                         $logged = new Typecho_Date($user->logged);
                         _e('最后登录: %s', $logged->word());


### PR DESCRIPTION
解决插件注入右上角导航会有两个| | 出现。
例如：插件名| |用户名|登出|网站 此种现象出现，原因为换行空格导致的。
![tim 20180919224205](https://user-images.githubusercontent.com/7334510/45760719-50e58680-bc5d-11e8-98db-4e25480e11f6.png)
