### PR TITLE
设置noopener防止钓鱼攻击

### DIFF
--- a/admin/plugins.php
+++ b/admin/plugins.php
@@ -40,7 +40,7 @@ include 'menu.php';
                                 <td><?php $activatedPlugins->description(); ?></td>
                                 <td><?php $activatedPlugins->version(); ?></td>
                                 <td><?php echo empty($activatedPlugins->homepage) ? $activatedPlugins->author : '<a href="' . $activatedPlugins->homepage
-                                . '">' . $activatedPlugins->author . '</a>'; ?></td>
+                                . '" rel="noopener noreferrer">' . $activatedPlugins->author . '</a>'; ?></td>
                                 <td>
                                     <?php if ($activatedPlugins->activate || $activatedPlugins->deactivate || $activatedPlugins->config || $activatedPlugins->personalConfig): ?>
                                         <?php if ($activatedPlugins->config): ?>
@@ -99,7 +99,7 @@ include 'menu.php';
                                 <td><?php $deactivatedPlugins->description(); ?></td>
                                 <td><?php $deactivatedPlugins->version(); ?></td>
                                 <td><?php echo empty($deactivatedPlugins->homepage) ? $deactivatedPlugins->author : '<a href="' . $deactivatedPlugins->homepage
-                                . '">' . $deactivatedPlugins->author . '</a>'; ?></td>
+                                . '" rel="noopener noreferrer">' . $deactivatedPlugins->author . '</a>'; ?></td>
                                 <td>
                                     <a href="<?php $security->index('/action/plugins-edit?activate=' . $deactivatedPlugins->name); ?>"><?php _e('启用'); ?></a>
                                 </td>


### PR DESCRIPTION
关于改属性的描述：
[链接地址中的target=”_blank”属性，为钓鱼攻击打开了大门](http://www.freebuf.com/vuls/113634.html)

[Target="_blank" - the most underestimated vulnerability ever](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/)

这个外链在插件列表的作者链接里，尽管php代码中没有显性加入 `target="_blank"` 但这个属性会被 `admin/common-js.php` 中的
```
t.attr('target', '_blank');
``` 
使得这个外链存在了隐患。