### PR TITLE
修复某些情况下index.php错误永久链接重定向问题

### DIFF
--- a/var/Widget/Options.php
+++ b/var/Widget/Options.php
@@ -206,7 +206,7 @@ class Widget_Options extends Typecho_Widget
     {
         return $this->widget('Widget_Security')->getTokenUrl(
             Typecho_Router::url('do', array('action' => 'login', 'widget' => 'Login'),
-            Typecho_Common::url('index.php', $this->rootUrl)));
+            Typecho_Common::url('', $this->index)));
     }
 
     /**

--- a/var/Widget/Options/Permalink.php
+++ b/var/Widget/Options/Permalink.php
@@ -202,7 +202,7 @@ RewriteRule . {$basePath}index.php [L]
     public function form()
     {
         /** 构建表格 */
-        $form = new Typecho_Widget_Helper_Form($this->security->getRootUrl('index.php/action/options-permalink'),
+        $form = new Typecho_Widget_Helper_Form($this->security->getIndex('/action/options-permalink'),
         Typecho_Widget_Helper_Form::POST_METHOD);
 
         if (!defined('__TYPECHO_REWRITE__')) {

--- a/var/Widget/Security.php
+++ b/var/Widget/Security.php
@@ -146,17 +146,6 @@ class Widget_Security extends Typecho_Widget
     }
 
     /**
-     * 获取绝对路由路径
-     *
-     * @param $path
-     * @return string
-     */
-    public function getRootUrl($path)
-    {
-        return Typecho_Common::url($this->getTokenUrl($path), $this->_options->rootUrl);
-    }
-
-    /**
      * 输出后台安全路径
      *
      * @param $path


### PR DESCRIPTION
环境:nginx+php_fpm，根据wiki上改了重定向...
从此再也没能登陆上后台...

大概看了一眼..改了这么些地方..全局搜了一波也没啥毛病了..
