### PR TITLE
修改默认主题中comments.php中的一处逻辑错误

### DIFF
--- a/usr/themes/default/comments.php
+++ b/usr/themes/default/comments.php
@@ -1,8 +1,8 @@
 <?php if (!defined('__TYPECHO_ROOT_DIR__')) exit; ?>
 <div id="comments">
     <?php $this->comments()->to($comments); ?>
-    <?php if ($comments->have()): ?>
 	<h3><?php $this->commentsNum(_t('暂无评论'), _t('仅有一条评论'), _t('已有 %d 条评论')); ?></h3>
+    <?php if ($comments->have()): ?>
     
     <?php $comments->listComments(); ?>
 


### PR DESCRIPTION
对评论数量的统计
```PHP
<h3><?php $this->commentsNum(_t('暂无评论'), _t('仅有一条评论'), _t('已有 %d 条评论')); ?></h3>
```
不应该只在有评论时才显示：
```PHP
<?php if ($comments->have()): ?>
```