### PR TITLE
fix error when use different protocol between reverse proxy and backend.

### DIFF
--- a/var/Typecho/Request.php
+++ b/var/Typecho/Request.php
@@ -237,7 +237,9 @@ class Typecho_Request
      */
     public static function isSecure()
     {
-        return (!empty($_SERVER['HTTPS']) && 'off' != strtolower($_SERVER['HTTPS'])) 
+        return (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && !strcasecmp('https', $_SERVER['HTTP_X_FORWARDED_PROTO']))
+            || (!empty($_SERVER['HTTP_X_FORWARDED_PORT']) && 443 == $_SERVER['HTTP_X_FORWARDED_PORT'])
+            || (!empty($_SERVER['HTTPS']) && 'off' != strtolower($_SERVER['HTTPS']))
             || (!empty($_SERVER['SERVER_PORT']) && 443 == $_SERVER['SERVER_PORT'])
             || (defined('__TYPECHO_SECURE__') && __TYPECHO_SECURE__);
     }


### PR DESCRIPTION
当使用cdn或反向代理时，前后段协议不一致时，baseurl截取错误，会出现两种协议的url。