### PR TITLE
解析失败返回原值

### DIFF
--- a/var/HyperDown.php
+++ b/var/HyperDown.php
@@ -488,7 +488,7 @@ class HyperDown
 
                 $result = isset( $self->_definitions[$matches[2]] ) ?
                     "<img src=\"{$self->_definitions[$matches[2]]}\" alt=\"{$escaped}\" title=\"{$escaped}\">"
-                    : $escaped;
+                    : $matches[0];
 
                 return $self->makeHolder($result);
             },
@@ -517,7 +517,7 @@ class HyperDown
                 );
                 $result = isset( $self->_definitions[$matches[2]] ) ?
                     "<a href=\"{$self->_definitions[$matches[2]]}\">{$escaped}</a>"
-                    : $escaped;
+                    : $matches[0];
 
                 return $self->makeHolder($result);
             },


### PR DESCRIPTION
这里返回的值应该是原值而不是解析过的值，例如 `[主页][分类1/分类2/分类3][页面][登录]` 被替换只剩下 `主页页面`