### PR TITLE
fix 修改错误信息显示,数据库错误显示详细错误信息,便于调试.

### DIFF
--- a/install.php
+++ b/install.php
@@ -503,7 +503,7 @@ Typecho_Cookie::set('__typecho_lang', $lang);
                                     } catch (Typecho_Db_Adapter_Exception $e) {
                                         $success = false;
                                         echo '<p class="message error">'
-                                        . _t('对不起, 无法连接数据库, 请先检查数据库配置再继续进行安装') . '</p>';
+                                            . _t($e->getMessage()) . '</p>';
                                     } catch (Typecho_Db_Exception $e) {
                                         $success = false;
                                         echo '<p class="message error">'


### PR DESCRIPTION
原来数据库错误,不显示详细错误信息,不方便查找故障原因,现在修改为显示详细信息,可以方便查看故障原因,并及时修复,方便拍错.