### PR TITLE
修复最近回复链接

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -73,7 +73,7 @@ $stat = Typecho_Widget::widget('Widget_Stat');
                         <?php while($comments->next()): ?>
                         <li>
                             <span><?php $comments->date('n.j'); ?></span>
-                            <a href="<?php $comments->permalink(); ?>" class="title"><?php $comments->author(true); ?></a>:
+                            <a href="<?php $comments->permalink(); ?>" class="title"><?php $comments->author(false); ?></a>:
                             <?php $comments->excerpt(35, '...'); ?>
                         </li>
                         <?php endwhile; ?>


### PR DESCRIPTION
用户链接把评论链接覆盖掉了导致并不能点击前往回复的链接地址