### PR TITLE
自动删除、略过空白字段

### DIFF
--- a/var/Widget/Abstract/Contents.php
+++ b/var/Widget/Abstract/Contents.php
@@ -474,7 +474,13 @@ class Widget_Abstract_Contents extends Widget_Abstract
             if (isset($exists[$name])) {
                 unset($exists[$name]);
             }
- 
+
+            if(empty($value)){
+                $this->db->query($this->db->delete('table.fields')
+                    ->where('cid = ? AND name = ?', $cid, $name));
+                continue;
+            }
+
             $this->setField($name, $type, $value, $cid);
         }
 


### PR DESCRIPTION
Typecho目前似乎只利用了str_value的字段类型，但是却并不会自动删除空白以及冗余字段。
在写入字段数值前检测value是否为空，如果为空则直接删除数据库内相同字段、跳过当前循环，避免无效字段写入到数据库中。
