### PR TITLE
解决评论列表中代码不自动换行问题

### DIFF
--- a/admin/css/style.css
+++ b/admin/css/style.css
@@ -36,7 +36,9 @@ a {
 /* line 39, ../scss/style.scss */
 code, pre, .mono {
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace; }
-
+code, pre{
+  white-space: pre-wrap;
+}
 /* line 43, ../scss/style.scss */
 .p {
   margin: 1em 0; }


### PR DESCRIPTION
如果解决评论列表中代码不自动换行，前方的评论者邮箱会被挤压的很厉害