### PR TITLE
修复通过 metaWeblog 接口新建草稿时返回 cid 错误的问题

### DIFF
--- a/var/Widget/Contents/Page/Edit.php
+++ b/var/Widget/Contents/Page/Edit.php
@@ -108,6 +108,9 @@ class Widget_Contents_Page_Edit extends Widget_Contents_Post_Edit implements Wid
             // 完成发布插件接口
             $this->pluginHandle()->finishSave($contents, $this);
 
+            /** 设置高亮 */
+            $this->widget('Widget_Notice')->highlight($this->cid);
+
             if ($this->request->isAjax()) {
                 $created = new Typecho_Date($this->options->time);
                 $this->response->throwJson(array(

--- a/var/Widget/Contents/Post/Edit.php
+++ b/var/Widget/Contents/Post/Edit.php
@@ -770,6 +770,9 @@ class Widget_Contents_Post_Edit extends Widget_Abstract_Contents implements Widg
             // 完成保存插件接口
             $this->pluginHandle()->finishSave($contents, $this);
 
+            /** 设置高亮 */
+            $this->widget('Widget_Notice')->highlight($this->cid);
+
             if ($this->request->isAjax()) {
                 $created = new Typecho_Date();
                 $this->response->throwJson(array(


### PR DESCRIPTION
接口中返回的 cid 是根据 highlight id 获取的，但新建草稿时未设置该值。