### PR TITLE
fix functions.php的themConfig中传递options参数修改表单样式不生效

### DIFF
--- a/var/Typecho/Widget/Helper/Form/Element/Text.php
+++ b/var/Typecho/Widget/Helper/Form/Element/Text.php
@@ -1,5 +1,7 @@
 <?php
-if (!defined('__TYPECHO_ROOT_DIR__')) exit;
+if (!defined('__TYPECHO_ROOT_DIR__')) {
+    exit;
+}
 /**
  * 文字输入表单项帮手
  *
@@ -28,10 +30,12 @@ class Typecho_Widget_Helper_Form_Element_Text extends Typecho_Widget_Helper_Form
      * @param array $options 选择项
      * @return Typecho_Widget_Helper_Layout
      */
-    public function input($name = NULL, array $options = NULL)
+    public function input($name = null, array $options = null)
     {
-        $input = new Typecho_Widget_Helper_Layout('input', array('id' => $name . '-0-' . self::$uniqueId,
-        'name' => $name, 'type' => 'text', 'class' => 'text'));
+        $orgClass = array('id' => $name . '-0-' . self::$uniqueId,
+        'name' => $name, 'type' => 'text', 'class' => 'text');
+        $class = empty($options) ? $orgClass : array_merge($orgClass, $options);
+        $input = new Typecho_Widget_Helper_Layout('input', $class);
         $this->container($input);
         $this->label->setAttribute('for', $name . '-0-' . self::$uniqueId);
         $this->inputs[] = $input;

--- a/var/Typecho/Widget/Helper/Form/Element/Textarea.php
+++ b/var/Typecho/Widget/Helper/Form/Element/Textarea.php
@@ -1,5 +1,7 @@
 <?php
-if (!defined('__TYPECHO_ROOT_DIR__')) exit;
+if (!defined('__TYPECHO_ROOT_DIR__')) {
+    exit;
+}
 /**
  * 多行文字域帮手
  *
@@ -28,9 +30,12 @@ class Typecho_Widget_Helper_Form_Element_Textarea extends Typecho_Widget_Helper_
      * @param array $options 选择项
      * @return Typecho_Widget_Helper_Layout
      */
-    public function input($name = NULL, array $options = NULL)
+    public function input($name = null, array $options = null)
     {
-        $input = new Typecho_Widget_Helper_Layout('textarea', array('id' => $name . '-0-' . self::$uniqueId, 'name' => $name));
+        $orgClass = array('id' => $name . '-0-' . self::$uniqueId, 'name' => $name);
+        $class = empty($options) ? $orgClass : array_merge($orgClass, $options);
+
+        $input = new Typecho_Widget_Helper_Layout('textarea', $class);
         $this->label->setAttribute('for', $name . '-0-' . self::$uniqueId);
         $this->container($input->setClose(false));
         $this->inputs[] = $input;


### PR DESCRIPTION
functions.php
```
 $siteStatistics = new Typecho_Widget_Helper_Form_Element_Textarea(
    'siteStatistics', 
    array('style'=>"height:200px"), 
    null, 
    ('CNZZ统计'), _t('填入自己的CNZZ统计代码,用于底部站点统计')
);
    $form->addInput($siteStatistics);
```
var\Typecho\Widget\Helper\Form\Element\Textarea.php
```
$orgClass = array('id' => $name . '-0-' . self::$uniqueId, 'name' => $name);
$class = empty($options) ? $orgClass : array_merge($orgClass, $options);
$input = new Typecho_Widget_Helper_Layout('textarea', $class);
```