### PR TITLE
修复 XmlRpc 接口的几个错误问题

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -18,6 +18,7 @@ RUN sed -i 's/archive.ubuntu.com/'$ubuntu_mirror'/g' /etc/apt/sources.list && \
 
 # install mysql
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server && \
+mkdir -p /var/run/mysqld && chown mysql:mysql /var/run/mysqld && \ # 增加此行
 #    sed -i -e "s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/mysqld.cnf && \
     sed -i 's/^\(log_error\s.*\)/# \1/' /etc/mysql/my.cnf && \
     echo "mysqld_safe &" > /tmp/mysql_config && \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -18,6 +18,7 @@ RUN sed -i 's/archive.ubuntu.com/'$ubuntu_mirror'/g' /etc/apt/sources.list && \
 
 # install mysql
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server && \
+mkdir -p /var/run/mysqld && chown mysql:mysql /var/run/mysqld && \
 #    sed -i -e "s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/mysqld.cnf && \
     sed -i 's/^\(log_error\s.*\)/# \1/' /etc/mysql/my.cnf && \
     echo "mysqld_safe &" > /tmp/mysql_config && \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -18,7 +18,6 @@ RUN sed -i 's/archive.ubuntu.com/'$ubuntu_mirror'/g' /etc/apt/sources.list && \
 
 # install mysql
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server && \
-mkdir -p /var/run/mysqld && chown mysql:mysql /var/run/mysqld && \ # 增加此行
 #    sed -i -e "s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/mysqld.cnf && \
     sed -i 's/^\(log_error\s.*\)/# \1/' /etc/mysql/my.cnf && \
     echo "mysqld_safe &" > /tmp/mysql_config && \

--- a/var/Widget/XmlRpc.php
+++ b/var/Widget/XmlRpc.php
@@ -395,8 +395,7 @@ class Widget_XmlRpc extends Widget_Abstract_Contents implements Widget_Interface
                 'dateCreated'            => new IXR_Date($this->options->timezone + $pages->created),
                 'userid'                 => $pages->authorId,
                 'page_id'                => intval($pages->cid),
-                /** todo:此处有疑问 */
-                'page_status'            => $this->typechoToWordpressStatus($pages->status, 'page'),
+                'page_status'            => $this->typechoToWordpressStatus(($pages->hasSaved || 'page_draft' == $pages->type) ? 'draft' : $pages->status, 'page'),
                 'description'            => $excerpt,
                 'title'                  => $pages->title,
                 'link'                   => $pages->permalink,

--- a/var/Widget/XmlRpc.php
+++ b/var/Widget/XmlRpc.php
@@ -1053,8 +1053,7 @@ class Widget_XmlRpc extends Widget_Abstract_Contents implements Widget_Interface
         
         $input = array();
         if (!empty($struct['status'])) {
-            $input['status'] = 'hold' == $input['status'] ? $input['status'] : 
-                $this->wordpressToTypechoStatus($struct['status']);
+            $input['status'] = $this->wordpressToTypechoStatus($struct['status'], 'comment');
         } else {
             $input['__typecho_all_comments'] = 'on';
         }

--- a/var/Widget/XmlRpc.php
+++ b/var/Widget/XmlRpc.php
@@ -1439,7 +1439,7 @@ class Widget_XmlRpc extends Widget_Abstract_Contents implements Widget_Interface
         /** 调整状态 */
         if (isset($content["{$type}_status"])) {
             $status = $this->wordpressToTypechoStatus($content["{$type}_status"], $type);
-            
+            $input['visibility'] = isset($content["visibility"]) ? $content["visibility"] : $status;
             if ('publish' == $status || 'waiting' == $status || 'private' == $status) {
                 $input['do'] = 'publish';
                 

--- a/var/Widget/XmlRpc.php
+++ b/var/Widget/XmlRpc.php
@@ -1604,7 +1604,7 @@ class Widget_XmlRpc extends Widget_Abstract_Contents implements Widget_Interface
                     'wp_author_id'           => $posts->authorId,
                     'wp_author_display_name' => $posts->author->screenName,
                     'date_created_gmt'       => new IXR_Date($posts->created),
-                    'post_status'            => $this->typechoToWordpressStatus($posts->status, 'post'),
+                    'post_status'            => $this->typechoToWordpressStatus(($posts->hasSaved || 'post_draft' == $posts->type) ? 'draft' : $posts->status, 'post'),
                     'custom_fields'          => array(),
                     'wp_post_format'         => 'standard',
                     'date_modified'          => new IXR_Date($this->options->timezone + $posts->modified),

--- a/var/Widget/XmlRpc.php
+++ b/var/Widget/XmlRpc.php
@@ -485,8 +485,8 @@ class Widget_XmlRpc extends Widget_Abstract_Contents implements Widget_Interface
      */
     public function wpEditPage($blogId, $pageId, $userName, $password, $content, $publish)
     {
-        $content['type'] = 'page';
-        $this->mwEditPost($blogId, $pageId, $userName, $password, $content, $publish);
+        $content['post_type'] = 'page';
+        $this->mwEditPost($pageId, $userName, $password, $content, $publish);
     }
 
 


### PR DESCRIPTION
**位于**```typecho/var/Widget/XmlRpc.php```

488.489行  **若不修改则导致无法编辑独立页面**
```php
$content['type'] = 'page';
$this->mwEditPost($blogId, $pageId, $userName, $password, $content, $publish);
```
其改为
```php
$content['post_type'] = 'page';
$this->mwEditPost($pageId, $userName, $password, $content, $publish);
```

1056行 **如不修改则导致无法获取垃圾评论和待审核评论**
```php 
$input['status'] = 'hold' == $input['status'] ? $input['status'] : $this->wordpressToTypechoStatus($struct['status']); 
``` 
**其改为** 
```php 
$input['status'] = $this->wordpressToTypechoStatus($struct['status'], 'comment');
```
1608行 **如不修改则导致无法判断该文章是否有草稿**
```php 
$this->typechoToWordpressStatus($posts->status, 'post')
``` 
**其改为** 
```php
$this->typechoToWordpressStatus(($posts->hasSaved || 'post_draft' == $posts->type) ? 'draft' : $posts->status, 'post')
```
399行 **如不修改则导致无法判断该独立页面是否有草稿**
```php 
$this->typechoToWordpressStatus($pages->status, 'page')
``` 
**其改为** 
```php
$this->typechoToWordpressStatus(($pages->hasSaved || 'page_draft' == $pages->type) ? 'draft' : $pages->status, 'page')
```

1442行 **如不修改则导致无法发布私密、草稿、等等状态的文章**
```php 
$status = $this->wordpressToTypechoStatus($content["{$type}_status"], $type);
``` 
**其后面增加一行** 
```php 
$input['visibility'] = isset($content["visibility"]) ? $content["visibility"] : $status;
```