### PR TITLE
fix: #926

### DIFF
--- a/var/Typecho/Common.php
+++ b/var/Typecho/Common.php
@@ -244,7 +244,11 @@ class Typecho_Common
         spl_autoload_register(array('Typecho_Common', '__autoLoad'));
 
         /** 兼容php6 */
-        if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc()) {
+        if (
+            version_compare(PHP_VERSION, '7.0.0', "<=") &&
+            function_exists('get_magic_quotes_gpc') &&
+            get_magic_quotes_gpc()
+        ) {
             $_GET = self::stripslashesDeep($_GET);
             $_POST = self::stripslashesDeep($_POST);
             $_COOKIE = self::stripslashesDeep($_COOKIE);


### PR DESCRIPTION
参考官方文档： [https://www.php.net/manual/en/function.get-magic-quotes-gpc.php](https://www.php.net/manual/en/function.get-magic-quotes-gpc.php)

DEPRECATED as of PHP 7.4.0.