### PR TITLE
Fix _editor.scss & style.css

### DIFF
--- a/admin/css/style.css
+++ b/admin/css/style.css
@@ -1615,7 +1615,7 @@ a.operate-reply {
   list-style: none;
   margin: 0;
   padding: 0;
-  height: 26px;
+  height: auto;
   line-height: 1; }
   /* line 15, ../scss/components/_editor.scss */
   .wmd-button-row li {

--- a/admin/scss/components/_editor.scss
+++ b/admin/scss/components/_editor.scss
@@ -9,7 +9,7 @@
   list-style: none;
   margin: 0;
   padding: 0;
-  height: 26px;
+  height: auto;
   line-height: 1;
 
   li {


### PR DESCRIPTION
修复当后台编辑器在小屏幕下时，部分图标被编辑框遮挡