### PR TITLE
fix: PasswordHash class fail to initialize on php 8

### DIFF
--- a/var/PasswordHash.php
+++ b/var/PasswordHash.php
@@ -39,7 +39,7 @@ class PasswordHash {
     var $portable_hashes;
     var $random_state;
 
-    function PasswordHash($iteration_count_log2, $portable_hashes)
+    function __construct($iteration_count_log2, $portable_hashes)
     {
         $this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 


### PR DESCRIPTION
目前 Typecho 使用的 `phpass / 0.2` 通过和类同名的函数进行初始化操作，在 PHP 8 中这种旧式构造函数将不会被执行，导致 `HashPassword()` 方法报错返回 `*`，无法正确完成密码的验证和重置。

> https://www.php.net/manual/en/language.oop5.decon.php
> Warning:  Old style constructors are DEPRECATED in PHP 7.0, and will be removed in a future version. You should always use __construct() in new code.

![图片](https://user-images.githubusercontent.com/18070833/85952229-70652380-b99a-11ea-9563-b92c988f6305.png)

![图片](https://user-images.githubusercontent.com/18070833/85952253-7ce97c00-b99a-11ea-87f6-10fb117cc94c.png)

