### PR TITLE
Skip Compression on Failure

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -13,7 +13,7 @@ update:
 	rm -f build/.gitignore
 	rm -f build/.gitattributes
 	for i in `find build/ -name '*.css'`; do echo $$i && java -Xmx32m -jar yuicompressor-2.4.2.jar $$i --charset UTF-8 -o $$i; done;
-	for i in `find build/admin/js/ -name '*.js'`; do echo $$i && java -Xmx32m -jar yuicompressor-2.4.2.jar $$i --charset UTF-8 -o $$i; done;
+	for i in `find build/admin/js/ -name '*.js'`; do echo $$i && java -Xmx32m -jar yuicompressor-2.4.2.jar $$i --charset UTF-8 -o $$i || true; done;
 	for i in `find build/ -name '*.php'`; do php -l $$i; done;
 
 


### PR DESCRIPTION
修复了 GitHub Action 持续构建失败的问题：

YUI Compressor 无法压缩 jQuery 2.2 是一个已知问题，详见 [这个 issue](https://github.com/yui/yuicompressor/issues/234)，压缩失败会返回非零值导致打包流程终止。

由于已经有了 UglifyJS（`tools/build.js`）对 `admin/src/js/` 的 Javascript 文件做压缩 ，修改了 `Makefile` 使 YUI Compressor 报错时依然继续打包。