### PR TITLE
方便用户在config.inc.php中重新定义语言目录

### DIFF
--- a/var/Widget/Options/General.php
+++ b/var/Widget/Options/General.php
@@ -29,7 +29,7 @@ class Widget_Options_General extends Widget_Abstract_Options implements Widget_I
      */
     public static function getLangs()
     {
-        $dir = defined('__TYPECHO_LANG_DIR__') ? __TYPECHO_LANG_DIR__ : __TYPECHO_ROOT_DIR__ . '/usr/langs';
+        $dir = defined('__TYPECHO_LANG_DIR__') ? __TYPECHO_ROOT_DIR__ . __TYPECHO_LANG_DIR__ : __TYPECHO_ROOT_DIR__ . '/usr/langs';
         $files = glob($dir . '/*.mo');
         $langs = array('zh_CN' => '简体中文');
 


### PR DESCRIPTION
方便用户在config.inc.php中重新定义语言目录，如`define('__TYPECHO_LANG_DIR__','/usr/langs');`，遵循和模板，插件一样的定义方法