### PR TITLE
fix personalConfig cache always overwrite user's config

### DIFF
--- a/var/Widget/Users/Profile.php
+++ b/var/Widget/Users/Profile.php
@@ -172,7 +172,9 @@ class Widget_Users_Profile extends Widget_Users_Edit implements Widget_Interface
 
         if (!empty($options)) {
             foreach ($options as $key => $val) {
-                $form->getInput($key)->value($val);
+                if (!$form->getInput($key)){
+                    $form->getInput($key)->value($val);
+                }
             }
         }
 


### PR DESCRIPTION
在插件配置personalConfig和personalConfigHandle之后，因为个人设置的字段在其他数据表，所以在处理personalConfigHandle钩子的时候已经给form 设置了对应需要显示的value ($form->value())，在这个时候form有值的情况下不能够从旧的缓存中读取旧的值。