### PR TITLE
ixr client url parse bug

### DIFF
--- a/var/IXR/Client.php
+++ b/var/IXR/Client.php
@@ -35,6 +35,14 @@ class IXR_Client
     private $port;
 
     /**
+     * 协议
+     *
+     * @access private
+     * @var string
+     */
+    private $scheme;
+
+    /**
      * 路径名称
      *
      * @access private
@@ -110,8 +118,16 @@ class IXR_Client
 
             // Assume we have been given a Url instead
             $bits = parse_url($server);
+
+            if (isset($bits['port'])) {
+                $this->port = $bits['port'];
+            } else if ('https' == $bits['scheme']) {
+                $this->port = 443;
+            } else {
+                $this->port = 80;
+            }
             $this->server = $bits['host'];
-            $this->port = ('https' == $bits['scheme']) ? 443 : 80;
+            $this->scheme = $bits['scheme'];
             $this->path = isset($bits['path']) ? $bits['path'] : '/';
 
             // Make absolutely sure we have a path
@@ -122,10 +138,12 @@ class IXR_Client
             /** Typecho_Common */
             require_once 'Typecho/Common.php';
 
-            $scheme = (443 == $port) ? 'https' : 'http';
+            if (is_null($this->scheme)) {
+                $this->scheme = 'http';
+            }
 
             $this->url = Typecho_Common::buildUrl(array(
-                'scheme'    =>  $scheme,
+                'scheme'    =>  $this->scheme,
                 'host'      =>  $server,
                 'path'      =>  $path,
                 'port'      =>  $port

--- a/var/IXR/Client.php
+++ b/var/IXR/Client.php
@@ -111,7 +111,7 @@ class IXR_Client
             // Assume we have been given a Url instead
             $bits = parse_url($server);
             $this->server = $bits['host'];
-            $this->port = isset($bits['port']) ? $bits['port'] : 80;
+            $this->port = ('https' == $bits['scheme']) ? 443 : 80;
             $this->path = isset($bits['path']) ? $bits['path'] : '/';
 
             // Make absolutely sure we have a path
@@ -122,8 +122,10 @@ class IXR_Client
             /** Typecho_Common */
             require_once 'Typecho/Common.php';
 
+            $scheme = (443 == $port) ? 'https' : 'http';
+
             $this->url = Typecho_Common::buildUrl(array(
-                'scheme'    =>  'http',
+                'scheme'    =>  $scheme,
                 'host'      =>  $server,
                 'path'      =>  $path,
                 'port'      =>  $port

--- a/var/IXR/Client.php
+++ b/var/IXR/Client.php
@@ -111,7 +111,7 @@ class IXR_Client
      * @param string $useragent 客户端
      * @return void
      */
-    public function __construct($server, $path = false, $port = 80, $useragent = self::DEFAULT_USERAGENT, $prefix = NULL)
+    public function __construct($server, $path = false, $port = 80, $scheme = 'http', $useragent = self::DEFAULT_USERAGENT, $prefix = NULL)
     {
         if (!$path) {
             $this->url = $server;
@@ -138,12 +138,8 @@ class IXR_Client
             /** Typecho_Common */
             require_once 'Typecho/Common.php';
 
-            if (is_null($this->scheme)) {
-                $this->scheme = 'http';
-            }
-
             $this->url = Typecho_Common::buildUrl(array(
-                'scheme'    =>  $this->scheme,
+                'scheme'    =>  $scheme,
                 'host'      =>  $server,
                 'path'      =>  $path,
                 'port'      =>  $port
@@ -152,6 +148,7 @@ class IXR_Client
             $this->server = $server;
             $this->path = $path;
             $this->port = $port;
+            $this->scheme = $scheme;
         }
 
         $this->prefix = $prefix;
@@ -229,7 +226,7 @@ class IXR_Client
      */
     public function __get($prefix)
     {
-        return new IXR_Client($this->server, $this->path, $this->port, $this->useragent, $this->prefix . $prefix . '.');
+        return new IXR_Client($this->server, $this->path, $this->port, $this->scheme, $this->useragent, $this->prefix . $prefix . '.');
     }
 
     /**

--- a/var/IXR/ClientMulticall.php
+++ b/var/IXR/ClientMulticall.php
@@ -15,8 +15,8 @@ if (!defined('__TYPECHO_ROOT_DIR__')) exit;
  */
 class IXR_ClientMulticall extends IXR_Client {
     var $calls = array();
-    function IXR_ClientMulticall($server, $path = false, $port = 80) {
-        parent::IXR_Client($server, $path, $port);
+    function IXR_ClientMulticall($server, $path = false, $port = 80, $scheme = 'http') {
+        parent::IXR_Client($server, $path, $port, $scheme);
         $this->useragent = 'The Incutio XML-RPC PHP Library (multicall client)';
     }
     function addCall() {


### PR DESCRIPTION
服务器地址强制为http和80端口，如果是https服务器就无法通过