### PR TITLE
自动关闭不活跃的 issue 和 PR

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,13 @@
+name: Close stale issues and PRs
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'


### PR DESCRIPTION
通过 [Close Stale Issues](https://github.com/marketplace/actions/close-stale-issues) 自动提醒长达六十天未活跃（即无新讨论和编辑）的 Issues 和 PRs，假定七天后仍未活跃即自动关闭。
