### PR TITLE
修复php8下插件建立的页面出现的报错问题

### DIFF
--- a/admin/common.php
+++ b/admin/common.php
@@ -3,7 +3,9 @@ if (!defined('__DIR__')) {
     define('__DIR__', dirname(__FILE__));
 }
 
-define('__TYPECHO_ADMIN__', true);
+if (!defined('__TYPECHO_ADMIN__')) {
+    define('__TYPECHO_ADMIN__', true);
+}
 
 /** 载入配置文件 */
 if (!defined('__TYPECHO_ROOT_DIR__') && !@include_once __DIR__ . '/../config.inc.php') {


### PR DESCRIPTION
比如友情链接插件，建立链接的页面就会报如下错误
Warning:  Constant __TYPECHO_ADMIN__ already defined in /admin/common.php on line 6