### PR TITLE
Fix HTTPS judgment bug

### DIFF
--- a/var/Typecho/Request.php
+++ b/var/Typecho/Request.php
@@ -419,6 +419,8 @@ class Request
     {
         return (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && !strcasecmp('https', $_SERVER['HTTP_X_FORWARDED_PROTO']))
             || (!empty($_SERVER['HTTP_X_FORWARDED_PORT']) && 443 == $_SERVER['HTTP_X_FORWARDED_PORT'])
+            || (!empty($_SERVER['HTTP_X_CLIENT_SCHEME']) && !strcasecmp('https', $_SERVER['HTTP_X_CLIENT_SCHEME']))
+            || (!empty($_SERVER['REQUEST_SCHEME']) && !strcasecmp('https', $_SERVER['REQUEST_SCHEME']))
             || (!empty($_SERVER['HTTPS']) && 'off' != strtolower($_SERVER['HTTPS']))
             || (!empty($_SERVER['SERVER_PORT']) && 443 == $_SERVER['SERVER_PORT'])
             || (defined('__TYPECHO_SECURE__') && __TYPECHO_SECURE__);


### PR DESCRIPTION
解决使用阿里云共享虚拟主机经济增强版时，通过HTTPS访问后台登陆页面时，程序生成的link与form标签使用HTTP导致无法登录的问题。