### PR TITLE
修复trackback与pingback无法正常工作的bug

### DIFF
--- a/var/Typecho/Http/Client.php
+++ b/var/Typecho/Http/Client.php
@@ -56,7 +56,7 @@ class Client
     /**
      * @var bool
      */
-    private $multipart = true;
+    private $multipart = false;
 
     /**
      * 需要在body中传递的值

--- a/var/Widget/Service.php
+++ b/var/Widget/Service.php
@@ -57,7 +57,7 @@ class Service extends BaseOptions implements ActionInterface
             set_time_limit(30);
         }
 
-        if (!empty($this->request->pingback)) {
+        if (!empty($this->request->getArray('pingback')[0])) {
             $links = $this->request->getArray('pingback');
             $permalinkPart = parse_url($permalink);
 
@@ -114,7 +114,7 @@ class Service extends BaseOptions implements ActionInterface
         }
 
         /** 发送trackback */
-        if (!empty($this->request->trackback)) {
+        if (!empty($this->request->getArray('trackback')[0])) {
             $links = $this->request->getArray('trackback');
 
             foreach ($links as $url) {


### PR DESCRIPTION
该Bug是由 [@eee0228中的$multipart](https://github.com/typecho/typecho/commit/eee0228fed04cf1d1ea4272731c2dfbf74869d9c#diff-c4724355cf2d1f4eb7d05395cce0850451ade8547f22fff89da2e295380abe86R59) 及[@dd4bf88](https://github.com/typecho/typecho/commit/dd4bf889de4e67578bb5d2317daee654220cfb25#diff-504985d91a7de2bf59361b125112caf0d3d7081473bf9f1046d6fc382881f03bR169)所引入的.

根据实现, 在[编辑和新增文章时](https://github.com/typecho/typecho/tree/d77a1ecad7698078fa583d21b5cde7bc93413d92/var/Widget/Contents/Post/Edit.php#L292), 为避免出现pingback/trackback导致的长时间阻塞问题, 会[进行一个2秒超时的请求](https://github.com/typecho/typecho/blob/d77a1ecad7698078fa583d21b5cde7bc93413d92/var/Widget/Service.php#L181)来[异步执行pingback/trackback](https://github.com/typecho/typecho/blob/d77a1ecad7698078fa583d21b5cde7bc93413d92/var/Widget/Service.php#L37).

在[@eee0228](https://github.com/typecho/typecho/commit/eee0228fed04cf1d1ea4272731c2dfbf74869d9c)中, 新增的 [setMultipart(bool $multipart)](https://github.com/typecho/typecho/commit/eee0228fed04cf1d1ea4272731c2dfbf74869d9c#diff-c4724355cf2d1f4eb7d05395cce0850451ade8547f22fff89da2e295380abe86R213)  似乎没有在任何地方使用.

这使得发送请求的时候$multipart始终为true, POST数据([通过setData传入的array](https://github.com/typecho/typecho/tree/d77a1ecad7698078fa583d21b5cde7bc93413d92/var/Widget/Service.php#L182))无法正常通过http_build_query组装为有效数据,从而引发了一系列的问题.

除此之外, 因[@dd4bf88](https://github.com/typecho/typecho/commit/dd4bf889de4e67578bb5d2317daee654220cfb25#diff-504985d91a7de2bf59361b125112caf0d3d7081473bf9f1046d6fc382881f03bR169)所做的更改(加入了与默认值类型的判断), 导致无法正确获取[$this->request->pingback](https://github.com/typecho/typecho/blob/d77a1ecad7698078fa583d21b5cde7bc93413d92/var/Widget/Service.php#L60)及[$this->request->trackback](https://github.com/typecho/typecho/blob/d77a1ecad7698078fa583d21b5cde7bc93413d92/var/Widget/Service.php#L117), 为了预防出现其他问题, 改用getArray进行判断.

另: empty貌似判断不了getArray返回的特殊空值([""]), 所以改为判断array[0], 不知是否有更好办法?

该PR同时修复了[#1363](https://github.com/typecho/typecho/issues/1363)的部分问题(解决日志第二行报错, 第一行疑似是pingback地址格式解析问题).