### PR TITLE
hyperdown: render escaped symbols correctly

### DIFF
--- a/var/Utils/HyperDown.php
+++ b/var/Utils/HyperDown.php
@@ -420,7 +420,7 @@ class HyperDown
         $text = preg_replace_callback(
             "/\\\(.)/u",
             function ($matches) {
-                $prefix = preg_match("/^[-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]$/", $matches[1]) ? '' : '\\';
+                $prefix = preg_match("/^[-\_\`\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]$/", $matches[1]) ? '' : '\\';
                 $escaped = htmlspecialchars($matches[1]);
                 $escaped = str_replace('$', '&dollar;', $escaped);
                 return $this->makeHolder($prefix . $escaped);


### PR DESCRIPTION
按照 Markdown 标准 https://daringfireball.net/projects/markdown/syntax#backslash, 以下字符应支持 \\ 转义。

```
\   backslash
`   backtick
*   asterisk
_   underscore
{}  curly braces
[]  square brackets
()  parentheses
#   hash mark
+   plus sign
-   minus sign (hyphen)
.   dot
!   exclamation mark
```
