### PR TITLE
fix CORS issues in preview page. 修复文章预览页面跨域问题

### DIFF
--- a/admin/write-js.php
+++ b/admin/write-js.php
@@ -281,7 +281,7 @@ $(document).ready(function() {
 
         var frame = $('<iframe frameborder="0" class="preview-frame preview-loading"></iframe>')
             .attr('src', './preview.php?cid=' + cid)
-            .attr('sandbox', 'allow-scripts')
+            .attr('sandbox', 'allow-same-origin allow-scripts')
             .appendTo(document.body);
 
         frame.load(function () {


### PR DESCRIPTION
Add 'allow-same-origin' into sandbox's attrs to fix that the article preview page does not match the real page.

给预览时的sandbox添加"allow-same-origin"，来避免跨域导致资源加载失效问题