### PR TITLE
修复管理员进入其他用户文章列表时显示所有文章的bug

### DIFF
--- a/admin/manage-posts.php
+++ b/admin/manage-posts.php
@@ -172,7 +172,7 @@ $isAllPosts = ('on' == $request->get('__typecho_all_posts') || 'on' == \Typecho\
                                             <?php endif; ?>
                                         </td>
                                         <td class="kit-hidden-mb"><a
-                                                href="<?php $options->adminUrl('manage-posts.php?uid=' . $posts->author->uid); ?>"><?php $posts->author(); ?></a>
+                                                href="<?php $options->adminUrl('manage-posts.php?__typecho_all_posts=off&uid=' . $posts->author->uid); ?>"><?php $posts->author(); ?></a>
                                         </td>
                                         <td class="kit-hidden-mb"><?php $categories = $posts->categories;
                                             $length = count($categories); ?>

--- a/admin/manage-users.php
+++ b/admin/manage-users.php
@@ -64,7 +64,7 @@ $users = \Widget\Users\Admin::alloc();
                                     <td class="kit-hidden-mb"><input type="checkbox" value="<?php $users->uid(); ?>"
                                                                      name="uid[]"/></td>
                                     <td class="kit-hidden-mb"><a
-                                            href="<?php $options->adminUrl('manage-posts.php?__typecho_all_posts=off&&uid=' . $users->uid); ?>"
+                                            href="<?php $options->adminUrl('manage-posts.php?__typecho_all_posts=off&uid=' . $users->uid); ?>"
                                             class="balloon-button left size-<?php echo \Typecho\Common::splitByCount($users->postsNum, 1, 10, 20, 50, 100); ?>"><?php $users->postsNum(); ?></a>
                                     </td>
                                     <td>

--- a/admin/manage-users.php
+++ b/admin/manage-users.php
@@ -64,7 +64,7 @@ $users = \Widget\Users\Admin::alloc();
                                     <td class="kit-hidden-mb"><input type="checkbox" value="<?php $users->uid(); ?>"
                                                                      name="uid[]"/></td>
                                     <td class="kit-hidden-mb"><a
-                                            href="<?php $options->adminUrl('manage-posts.php?uid=' . $users->uid); ?>"
+                                            href="<?php $options->adminUrl('manage-posts.php?__typecho_all_posts=off&&uid=' . $users->uid); ?>"
                                             class="balloon-button left size-<?php echo \Typecho\Common::splitByCount($users->postsNum, 1, 10, 20, 50, 100); ?>"><?php $users->postsNum(); ?></a>
                                     </td>
                                     <td>


### PR DESCRIPTION
bug描述：当管理员在文章管理页面，点击所有查看所有文章后，再通过这个页面进入作者文章管理页面时，仍会显示所有文章而不是当前作者的文章