### PR TITLE
Fix QUIC/https Mixed Content

### DIFF
--- a/var/Typecho/Request.php
+++ b/var/Typecho/Request.php
@@ -430,6 +430,7 @@ class Request
     public function isSecure(): bool
     {
         return (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && !strcasecmp('https', $_SERVER['HTTP_X_FORWARDED_PROTO']))
+            || (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && !strcasecmp('quic', $_SERVER['HTTP_X_FORWARDED_PROTO']))
             || (!empty($_SERVER['HTTP_X_FORWARDED_PORT']) && 443 == $_SERVER['HTTP_X_FORWARDED_PORT'])
             || (!empty($_SERVER['HTTPS']) && 'off' != strtolower($_SERVER['HTTPS']))
             || (!empty($_SERVER['SERVER_PORT']) && 443 == $_SERVER['SERVER_PORT'])


### PR DESCRIPTION
**修正 QUIC 协议访问 CDN 可能会出现的混合内容错误**
**使用 QUIC 协议访问 CDN，判断为 https**

---
部分支持 QUIC 协议访问的 CDN 回源携带的 ``HTTP_X_FORWARDED_PROTO`` 是 ``quic``，如果未能正确识别 QUIC 协议访问，则可能会导致请求出现混合内容错误
