### PR TITLE
Fix category creation error when using xmlrpc

### DIFF
--- a/var/Typecho/Widget/Helper/Form.php
+++ b/var/Typecho/Widget/Helper/Form.php
@@ -3,6 +3,7 @@
 namespace Typecho\Widget\Helper;
 
 use Typecho\Cookie;
+use Typecho\Request;
 use Typecho\Validate;
 use Typecho\Widget\Helper\Form\Element;
 
@@ -131,10 +132,10 @@ class Form extends Layout
     public function getAllRequest(): array
     {
         $result = [];
-        $source = (self::POST_METHOD == $this->getAttribute('method')) ? $_POST : $_GET;
+        $request = Request::getInstance();
 
         foreach ($this->inputs as $name => $input) {
-            $result[$name] = $source[$name] ?? null;
+            $result[$name] = $request->get($name, null);
         }
         return $result;
     }
@@ -204,10 +205,10 @@ class Form extends Layout
     public function getParams(array $params): array
     {
         $result = [];
-        $source = (self::POST_METHOD == $this->getAttribute('method')) ? $_POST : $_GET;
+        $request = Request::getInstance();
 
         foreach ($params as $param) {
-            $result[$param] = $source[$param] ?? null;
+            $result[$param] = $request->get($param, null);
         }
 
         return $result;

--- a/var/Widget/XmlRpc.php
+++ b/var/Widget/XmlRpc.php
@@ -463,17 +463,23 @@ class XmlRpc extends Contents implements ActionInterface, Hook
      */
     public function wpNewCategory(int $blogId, string $userName, string $password, array $category): int
     {
-
         /** 开始接受数据 */
         $input['name'] = $category['name'];
         $input['slug'] = Common::slugName(empty($category['slug']) ? $category['name'] : $category['slug']);
         $input['parent'] = $category['parent_id'] ?? ($category['parent'] ?? 0);
         $input['description'] = $category['description'] ?? $category['name'];
 
+        $_POST = array_replace_recursive($_POST, $input);
+
         /** 调用已有组件 */
         $categoryWidget = CategoryEdit::alloc(null, $input, function (CategoryEdit $category) {
             $category->insertCategory();
         });
+
+        if (!$categoryWidget->have()) {
+            throw new Exception(_t('分类不存在'), 404);
+        }
+
         return $categoryWidget->mid;
     }
 

--- a/var/Widget/XmlRpc.php
+++ b/var/Widget/XmlRpc.php
@@ -469,8 +469,6 @@ class XmlRpc extends Contents implements ActionInterface, Hook
         $input['parent'] = $category['parent_id'] ?? ($category['parent'] ?? 0);
         $input['description'] = $category['description'] ?? $category['name'];
 
-        $_POST = array_replace_recursive($_POST, $input);
-
         /** 调用已有组件 */
         $categoryWidget = CategoryEdit::alloc(null, $input, function (CategoryEdit $category) {
             $category->insertCategory();
@@ -1839,7 +1837,7 @@ EOF;
                 'wp.suggestCategories'      => [$this, 'wpSuggestCategories'],
                 'wp.uploadFile'             => [$this, 'mwNewMediaObject'],
 
-                /** New Wordpress API since 2.9.2 */
+                /** New WordPress API since 2.9.2 */
                 'wp.getUsersBlogs'          => [$this, 'wpGetUsersBlogs'],
                 'wp.getTags'                => [$this, 'wpGetTags'],
                 'wp.deleteCategory'         => [$this, 'wpDeleteCategory'],


### PR DESCRIPTION
原因是在insertCategory时validate被goBack了，获取到的$formData是空的

Fix #1440
Fix #1340