### PR TITLE
Fix #1495

### DIFF
--- a/var/Widget/Base/Contents.php
+++ b/var/Widget/Base/Contents.php
@@ -928,7 +928,7 @@ class Contents extends Base implements QueryInterface
     {
         $html = Contents::pluginHandle()->trigger($parsed)->autoP($text);
 
-        if (!$parsed) {
+        if (!$parsed && $text) {
             static $parser;
 
             if (empty($parser)) {


### PR DESCRIPTION
Argument 1 passed to Utils\AutoP::parse() must be of the type string, null given