### PR TITLE
支持自定义归档方式，目前可支持year和month

### DIFF
--- a/install.php
+++ b/install.php
@@ -300,7 +300,8 @@ function install_get_default_options(): array
             'attachmentTypes' => '@image@',
             'secret' => \Typecho\Common::randString(32, true),
             'installed' => 0,
-            'allowXmlRpc' => 2
+            'allowXmlRpc' => 2,
+            'postArchiveType' => 'month'
         ];
     }
 

--- a/var/Widget/Contents/Post/Date.php
+++ b/var/Widget/Contents/Post/Date.php
@@ -36,6 +36,16 @@ class Date extends Base
      */
     public function execute()
     {
+        var_dump(isset($this->options->postArchiveType));
+        if (isset($this->options->postArchiveType)) {
+            switch ($this->options->postArchiveType) {
+                case 'year':
+                    $this->parameter->setDefault('format=Y&type=year', true);
+                    break;
+                case 'month':
+                    $this->parameter->setDefault('format=F Y&type=month', true);
+            }
+        }
         /** 设置参数默认值 */
         $this->parameter->setDefault('format=Y-m&type=month&limit=0');
 

--- a/var/Widget/Options.php
+++ b/var/Widget/Options.php
@@ -97,6 +97,7 @@ if (!defined('__TYPECHO_ROOT_DIR__')) {
  * @property array $plugins
  * @property string $secret
  * @property bool $installed
+ * @property string $postArchiveType
  */
 class Options extends Base
 {

--- a/var/Widget/Options/General.php
+++ b/var/Widget/Options/General.php
@@ -91,7 +91,8 @@ class General extends Options implements ActionInterface
             'allowRegister',
             'allowXmlRpc',
             'lang',
-            'timezone'
+            'timezone',
+            'postArchiveType'
         );
         $settings['attachmentTypes'] = $this->request->getArray('attachmentTypes');
 
@@ -290,6 +291,16 @@ class General extends Options implements ActionInterface
             _t('用逗号 "," 将后缀名隔开, 例如: %s', '<code>cpp, h, mak</code>')
         );
         $form->addInput($attachmentTypes->multiMode());
+
+
+        /** 归档类型 */
+        $postArchiveType = new Form\Element\Radio(
+            'postArchiveType',
+            ['year' => _t('按年归档'), 'month' => _t('按月归档')],
+            $this->options->postArchiveType,
+            _t('归档类型')
+        );
+        $form->addInput($postArchiveType);
 
         /** 提交按钮 */
         $submit = new Form\Element\Submit('submit', null, _t('保存设置'));


### PR DESCRIPTION
当博客文章时间跨越比较大时，首页默认的按月归档会导致页面被拉长，因此可以做一个配置支持选择按月归档还是按年归档。