### PR TITLE
Support ssl for pdo_mysql and mysqli

### DIFF
--- a/install.php
+++ b/install.php
@@ -925,7 +925,7 @@ function install_step_2_perform()
             'dbCharset' => 'utf8mb4',
             'dbDatabase' => null,
             'dbEngine' => 'InnoDB',
-            'dbSsl' => null,
+            'dbSslCa' => null,
             'dbSslVerify' => 'on',
         ],
         'Pgsql' => [

--- a/install.php
+++ b/install.php
@@ -924,7 +924,9 @@ function install_step_2_perform()
             'dbPassword' => null,
             'dbCharset' => 'utf8mb4',
             'dbDatabase' => null,
-            'dbEngine' => 'InnoDB'
+            'dbEngine' => 'InnoDB',
+            'dbSsl' => null,
+            'dbSslVerify' => 'on',
         ],
         'Pgsql' => [
             'dbHost' => 'localhost',
@@ -967,7 +969,9 @@ function install_step_2_perform()
             'dbEngine',
             'dbPrefix',
             'dbAdapter',
-            'dbNext'
+            'dbNext',
+            'dbSsl',
+            'dbSslVerify',
         ]);
     }
 
@@ -1064,7 +1068,7 @@ function install_step_2_perform()
             $installDb->addServer($dbConfig, \Typecho\Db::READ | \Typecho\Db::WRITE);
             $installDb->query('SELECT 1=1');
         } catch (\Typecho\Db\Adapter\ConnectionException $e) {
-            install_raise_error(_t('对不起, 无法连接数据库, 请先检查数据库配置再继续进行安装'));
+            install_raise_error(_t('对不起, 无法连接数据库, 请先检查数据库配置再继续进行安装: "%s"', $e->getMessage()));
         } catch (\Typecho\Db\Exception $e) {
             install_raise_error(_t('安装程序捕捉到以下错误: "%s". 程序被终止, 请检查您的配置信息.', $e->getMessage()));
         }

--- a/install/Mysql.php
+++ b/install/Mysql.php
@@ -63,4 +63,22 @@
             </select>
         </li>
     </ul>
+
+    <ul class="typecho-option">
+        <li>
+            <label class="typecho-label" for="dbSsl"><?php _e('数据库 SSL 认证'); ?></label>
+            <input type="text" class="text" name="dbSsl" id="dbSsl"/>
+            <p class="description"><?php _e('如果您的数据库启用了 SSL，请填写 CA 证书路径，否则请留空'); ?></p>
+        </li>
+    </ul>
+
+    <ul class="typecho-option">
+        <li>
+            <label class="typecho-label" for="dbSslVerify"><?php _e('数据库 SSL 服务端证书验证'); ?></label>
+            <select name="dbSslVerify" id="dbSslVerify">
+                <option value="on"><?php _e('验证'); ?></option>
+                <option value="off"><?php _e('不验证'); ?></option>
+            </select>
+        </li>
+    </ul>
 </details>

--- a/install/Mysql.php
+++ b/install/Mysql.php
@@ -66,18 +66,18 @@
 
     <ul class="typecho-option">
         <li>
-            <label class="typecho-label" for="dbSsl"><?php _e('数据库 SSL 认证'); ?></label>
-            <input type="text" class="text" name="dbSsl" id="dbSsl"/>
+            <label class="typecho-label" for="dbSslCa"><?php _e('数据库 SSL 证书'); ?></label>
+            <input type="text" class="text" name="dbSslCa" id="dbSslCa"/>
             <p class="description"><?php _e('如果您的数据库启用了 SSL，请填写 CA 证书路径，否则请留空'); ?></p>
         </li>
     </ul>
 
     <ul class="typecho-option">
         <li>
-            <label class="typecho-label" for="dbSslVerify"><?php _e('数据库 SSL 服务端证书验证'); ?></label>
+            <label class="typecho-label" for="dbSslVerify"><?php _e('启用数据库 SSL 服务端证书验证'); ?></label>
             <select name="dbSslVerify" id="dbSslVerify">
-                <option value="on"><?php _e('验证'); ?></option>
-                <option value="off"><?php _e('不验证'); ?></option>
+                <option value="on"><?php _e('启用'); ?></option>
+                <option value="off"><?php _e('不启用'); ?></option>
             </select>
         </li>
     </ul>

--- a/var/Typecho/Db/Adapter/Mysqli.php
+++ b/var/Typecho/Db/Adapter/Mysqli.php
@@ -47,19 +47,28 @@ class Mysqli implements Adapter
      */
     public function connect(Config $config): \mysqli
     {
+        $mysqli = mysqli_init();
+        if ($mysqli) {
+            if ($config->ssl) {
+                $mysqli->ssl_set(null, null, $config->ssl, null, null);
+            }
 
-        if (
-            $this->dbLink = @mysqli_connect(
+            $mysqli->real_connect(
                 $config->host,
                 $config->user,
                 $config->password,
                 $config->database,
-                (empty($config->port) ? null : $config->port)
-            )
-        ) {
+                (empty($config->port) ? null : $config->port),
+                null,
+                $config->verifyservercert == 'off' ? MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT : null
+            );
+
+            $this->dbLink = $mysqli;
+
             if ($config->charset) {
                 $this->dbLink->query("SET NAMES '{$config->charset}'");
             }
+
             return $this->dbLink;
         }
 

--- a/var/Typecho/Db/Adapter/Mysqli.php
+++ b/var/Typecho/Db/Adapter/Mysqli.php
@@ -49,8 +49,12 @@ class Mysqli implements Adapter
     {
         $mysqli = mysqli_init();
         if ($mysqli) {
-            if ($config->ssl) {
-                $mysqli->ssl_set(null, null, $config->ssl, null, null);
+            if (!empty($config->sslCa)) {
+                $mysqli->ssl_set(null, null, $config->sslCa, null, null);
+
+                if (isset($config->sslVerify)) {
+                    $mysqli->options(MYSQLI_OPT_SSL_VERIFY_SERVER_CERT, $config->sslVerify);
+                }
             }
 
             $mysqli->real_connect(
@@ -58,9 +62,7 @@ class Mysqli implements Adapter
                 $config->user,
                 $config->password,
                 $config->database,
-                (empty($config->port) ? null : $config->port),
-                null,
-                $config->verifyservercert == 'off' ? MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT : null
+                (empty($config->port) ? null : $config->port)
             );
 
             $this->dbLink = $mysqli;

--- a/var/Typecho/Db/Adapter/Pdo/Mysql.php
+++ b/var/Typecho/Db/Adapter/Pdo/Mysql.php
@@ -51,11 +51,20 @@ class Mysql extends Pdo
      */
     public function init(Config $config): \PDO
     {
+        $options = [];
+        if ($config->ssl) {
+            $options[\PDO::MYSQL_ATTR_SSL_CA] = $config->ssl;
+            if ($config->sslverify == 'off') {
+                // FIXME: https://github.com/php/php-src/issues/8577
+                $options[\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = false;
+            }
+        }
         $pdo = new \PDO(
             !empty($config->dsn)
                 ? $config->dsn : "mysql:dbname={$config->database};host={$config->host};port={$config->port}",
             $config->user,
-            $config->password
+            $config->password,
+            $options
         );
         $pdo->setAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
 

--- a/var/Typecho/Db/Adapter/Pdo/Mysql.php
+++ b/var/Typecho/Db/Adapter/Pdo/Mysql.php
@@ -52,13 +52,15 @@ class Mysql extends Pdo
     public function init(Config $config): \PDO
     {
         $options = [];
-        if ($config->ssl) {
-            $options[\PDO::MYSQL_ATTR_SSL_CA] = $config->ssl;
-            if ($config->sslverify == 'off') {
+        if (!empty($config->sslCa)) {
+            $options[\PDO::MYSQL_ATTR_SSL_CA] = $config->sslCa;
+
+            if (isset($config->sslVerify)) {
                 // FIXME: https://github.com/php/php-src/issues/8577
-                $options[\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = false;
+                $options[\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = $config->sslVerify;
             }
         }
+
         $pdo = new \PDO(
             !empty($config->dsn)
                 ? $config->dsn : "mysql:dbname={$config->database};host={$config->host};port={$config->port}",


### PR DESCRIPTION
支持了一下简版的ssl，测试planetscale通过。

腾讯云的云db，开启ssl以后连接使用证书，需要关闭验证，那开启ssl意义好像就没了 😅

```
Peer certificate CN=`TencentDB ROOT SERVER-CA' did not match expected CN...
```

Close #1508