### PR TITLE
fix: adding checkbox options after theme initialization cannot be saved.

### DIFF
--- a/var/Widget/Themes/Config.php
+++ b/var/Widget/Themes/Config.php
@@ -71,7 +71,9 @@ class Config extends BaseOptions
 
         if (!empty($inputs)) {
             foreach ($inputs as $key => $val) {
-                $form->getInput($key)->value($this->options->{$key});
+                if ($this->options->{$key}) {
+                    $form->getInput($key)->value($this->options->{$key});
+                }
             }
         }
 


### PR DESCRIPTION
issue #1590 