### PR TITLE
fix: Fix #1597

### DIFF
--- a/admin/custom-fields-js.php
+++ b/admin/custom-fields-js.php
@@ -30,7 +30,7 @@ $(document).ready(function () {
     });
 
     $('#custom-field button.operate-add').click(function () {
-        var html = '<tr><td><input type="text" name="fieldNames[]" placeholder="<?php _e('字段名称'); ?>" class="text-s w-100"></td>'
+        var html = '<tr><td><input type="text" name="fieldNames[]" placeholder="<?php _e('字段名称'); ?>" pattern="^[_a-zA-Z][_a-zA-Z0-9]*$" oninput="this.reportValidity()" class="text-s w-100"></td>'
                 + '<td><select name="fieldTypes[]" id="">'
                 + '<option value="str"><?php _e('字符'); ?></option>'
                 + '<option value="int"><?php _e('整数'); ?></option>'

--- a/admin/custom-fields.php
+++ b/admin/custom-fields.php
@@ -26,7 +26,7 @@ $defaultFields = isset($post) ? $post->getDefaultFieldItems() : $page->getDefaul
                 <td>
                     <label for="fieldname" class="sr-only"><?php _e('字段名称'); ?></label>
                     <input type="text" name="fieldNames[]" value="<?php echo htmlspecialchars($field['name']); ?>"
-                           id="fieldname" class="text-s w-100">
+                           id="fieldname" pattern="^[_a-zA-Z][_a-zA-Z0-9]*$" oninput="this.reportValidity()" class="text-s w-100">
                 </td>
                 <td>
                     <label for="fieldtype" class="sr-only"><?php _e('字段类型'); ?></label>
@@ -56,7 +56,7 @@ $defaultFields = isset($post) ? $post->getDefaultFieldItems() : $page->getDefaul
                 <td>
                     <label for="fieldname" class="sr-only"><?php _e('字段名称'); ?></label>
                     <input type="text" name="fieldNames[]" placeholder="<?php _e('字段名称'); ?>" id="fieldname"
-                           class="text-s w-100">
+                           class="text-s w-100" pattern="^[_a-zA-Z][_a-zA-Z0-9]*$" oninput="this.reportValidity()">
                 </td>
                 <td>
                     <label for="fieldtype" class="sr-only"><?php _e('字段类型'); ?></label>


### PR DESCRIPTION
这条 PR 修复了 #1597 问题，其问题的核心是在 Contents.php 当中的这段 Code:

```php
            if (!$this->checkFieldName($name)) {
                continue;
            }
```

它检查了 field 名称的「有效性」，并且会自动过滤无效的field，无效 field 的标准是：

```php
    public function checkFieldName(string $name): bool
    {
        return preg_match("/^[_a-z][_a-z0-9]*$/i", $name);
    }
```

但是这一标准并没有在前端进行检验，提交的时候如果不满足条件过滤过程是静默的，这会让用于产生自己的数据没有被正确保存的幻觉。

本 PR 加入了一个实时的 field name 校验，如果输入了非法值，浏览器会立刻提醒用户进行修改。

![image](https://github.com/typecho/typecho/assets/1384036/55fc0fa0-6f1f-4339-aca1-651cf8d840fe)
   