### PR TITLE
修复“在查看某一分类或标签时无法正确生成分页链接”

### DIFF
--- a/var/Widget/Base/Metas.php
+++ b/var/Widget/Base/Metas.php
@@ -57,7 +57,7 @@ class Metas extends Base implements QueryInterface, RowFilterInterface, PrimaryK
             case 'directory':
                 return implode('/', array_map('urlencode', $this->directory));
             default:
-                return '';
+                return '{' . $key . '}';
         }
     }
 


### PR DESCRIPTION
Fix #1672 

问题的发生过程：
- `Metas` 这里不知道为什么没有处理好 `getRouterParam()` 的默认情况。
- `Router` 在 `getRouterParam()` 时无法根据 `$route['params']` 生成正确的 `{page}` 模板参数。
- `Box` 中会对 `{page}` 模板参数进行字符串替换：`str_replace($this->pageHolder, $i, $this->pageTemplate)` 从而得到包含分页后缀的链接，但由于上面的过程不正确，这里得到的链接就缺失了分页后缀。

顺便排查了所有的 `ParamsDelegateInterface` ，大家在 `getRouterParam()` 的时候，default 情况都会将 `$key` 组合为 `{$key}` 成为模板参数，不知道为什么唯独 `Metas` 这里漏掉了。

Test：

![image](https://github.com/typecho/typecho/assets/24606814/90285e0d-161e-493d-9026-277d1cf7a528)

观察生成的链接，确认分页后缀存在，且点击按钮能正常跳转分页。
