### PR TITLE
Fix unable to preview revisions

### DIFF
--- a/var/Widget/Archive.php
+++ b/var/Widget/Archive.php
@@ -1661,19 +1661,11 @@ EOF;
         }
 
         /** 设置归档类型 */
-        [$this->archiveType] = explode('_', $this->type);
-
-        /** 特殊处理 revision */
-        if ('revision' == $this->archiveType) {
-            $parent = $this->db->fetchRow(
-                $this->select('type')
-                    ->where(
-                        'table.contents.cid = ?',
-                        $this->parent
-                    )
-                    ->limit(1)
-            );
-            $this->archiveType = $parent['type'];
+        if ($this->parameter->preview && $this->type === 'revision') {
+            $parent = ContentsFrom::allocWithAlias($this->parent, ['cid' => $this->parent]);
+            $this->archiveType = $parent->type;
+        } else {
+            [$this->archiveType] = explode('_', $this->type);
         }
 
         /** 设置归档缩略名 */

--- a/var/Widget/Archive.php
+++ b/var/Widget/Archive.php
@@ -1663,6 +1663,19 @@ EOF;
         /** 设置归档类型 */
         [$this->archiveType] = explode('_', $this->type);
 
+        /** 特殊处理 revision */
+        if ('revision' == $this->archiveType) {
+            $parent = $this->db->fetchRow(
+                $this->select('type')
+                    ->where(
+                        'table.contents.cid = ?',
+                        $this->parent
+                    )
+                    ->limit(1)
+            );
+            $this->archiveType = $parent['type'];
+        }
+
         /** 设置归档缩略名 */
         $this->archiveSlug = ('post' == $this->archiveType || 'attachment' == $this->archiveType)
             ? $this->cid : $this->slug;


### PR DESCRIPTION
Fix #1686 

### 问题根因

打了一下 stacktrace ：

```
Typed property Widget\Archive::$countSql must not be accessed before initialization
Error: Typed property Widget\Archive::$countSql must not be accessed before initialization in <hide>/var/Widget/Archive.php:437
Stack trace:
#0 <hide>/var/Widget/Archive.php(712): Widget\Archive->getTotal()
#1 <hide>/usr/themes/default/index.php(39): Widget\Archive->pageNav()
#2 <hide>/var/Widget/Archive.php(1345): require_once('...')
#3 <hide>/admin/preview.php(19): Widget\Archive->render()
#4 {main}
```

追踪下去发现 `Archive.php(1345)` 这里引错了文件：
```
/** 输出模板 */
require_once $this->themeDir . $this->themeFile;
```

在预览时，本来这里应该根据文章类别，去引主题中的 `page.php` / `post.php` ，但这里却引用了 `index.php` ，造成了后续的错乱。

继续追踪，发现其根据 `archiveType` 决定引用的对象，但这里的 `archiveType` 的值却是 `revision` ，主题里没有 `revision.php` 这个文件，于是 fallback 到了 `index.php` 。

那么 `archiveType` 为什么会是 `revision` 呢？
看了一下，这好像是新版的修改？
原来草稿的 `type` 应该是 `post_draft` 和 `page_draft` ，但新版区分了“草稿”（新文章）和“已修订”（对已有文章的修改），“草稿”保留原有 `type` 命名，“已修订” 的 `type` 则被命名为 `revision`。

但这就引入了一个问题，原先 `archiveType` 是根据 `type` 的前缀生成的（应该是吧）：
```
/** 设置归档类型 */
[$this->archiveType] = explode('_', $this->type);
```

比如 `type` 为 `post_draft` ，那么 `archiveType` 就生成为 `post` ，就采用主题中的 `post.php` 显示。
但是现在，不管是 post 的已修订，还是 page 的已修订，都被命名为了 `revision` ，没有这个可供判断呈现方式的前缀了。
于是 `archiveType` 就全部被生成为了 `revision` ，造成了上面的一系列问题。

### 解决方案

感觉从根本上解决，得改命名方式？比如具体区分 `post_revision` 和 `page_revision` ？
但这样改动好像有点太大了，而且会引入新的版本兼容问题🤔

于是这个 PR 用了比较讨巧的方式：当 `archiveType` 为 `revision` 时，取其 `parent` 的 `type` 作为实际 `archiveType` ，从而加载正确的主题文件。

Test：已修订的 post 和 page 都可以正常预览。

不太会 php ，不一定是最佳实践，还望笑纳 :)