### PR TITLE
Fix unable to show attachment parent in manage-medias

### DIFF
--- a/var/Widget/Contents/Attachment/Admin.php
+++ b/var/Widget/Contents/Attachment/Admin.php
@@ -62,7 +62,7 @@ class Admin extends Contents
     protected function ___parentPost(): Config
     {
         return new Config($this->db->fetchRow(
-            $this->select()->where('table.contents.cid = ?', $this->parentId)->limit(1)
+            $this->select()->where('table.contents.cid = ?', $this->parent)->limit(1)
         ));
     }
 }


### PR DESCRIPTION
Fix #1692

Test:
![image](https://github.com/typecho/typecho/assets/24606814/6b198163-aef5-4a28-8f19-a5986bf19f99)
