### PR TITLE
Fix unable to delete attachment from filesystem

### DIFF
--- a/var/Widget/Upload.php
+++ b/var/Widget/Upload.php
@@ -38,7 +38,7 @@ class Upload extends Contents implements ActionInterface
             return $result;
         }
 
-        return @unlink(__TYPECHO_ROOT_DIR__ . '/' . $content['attachment']->path);
+        return @unlink(__TYPECHO_ROOT_DIR__ . '/' . json_decode($content['text'])->path);
     }
 
     /**


### PR DESCRIPTION
Fix #1694

### 问题根因

```
$row = $this->db->fetchRow($this->select()
    ->where('table.contents.type = ?', 'attachment')
    ->where('table.contents.cid = ?', $post)
    ->limit(1), [$this, 'push']);

if ($this->isWriteable(clone $condition) && $this->delete($condition)) {
    /** 删除文件 */
    Upload::deleteHandle($row);
```

删除文件时，传入给 `deleteHandle()` 的是数据库的原始信息。
我们应该按照数据库的格式去解包这些信息，即：

![image](https://github.com/typecho/typecho/assets/24606814/fb9cd260-7cf7-4b46-ba9f-0e042c62b5cb)

也就是把 text 列解析为 json 对象后，取其中的 path 值。
先前的取 path 方式和实际对象结构不匹配，造成 path 未能被正常取出，进而造成文件无法删除。

Test:
分别从“管理文件”和编辑文章页面删除文件，确认文件从文件系统上消失。
