### PR TITLE
fix: getHeader for Content-Type & Content-Length

### DIFF
--- a/var/Typecho/Request.php
+++ b/var/Typecho/Request.php
@@ -420,8 +420,14 @@ class Request
      */
     public function getHeader(string $key, ?string $default = null): ?string
     {
-        $key = 'HTTP_' . strtoupper(str_replace('-', '_', $key));
-        return $this->getServer($key, $default);
+        $key = strtoupper(str_replace('-', '_', $key));
+        
+        // Content-Type 和 Content-Length 这两个 header 还需要从不带 HTTP_ 的 key 尝试获取
+        if (in_array($key, ['CONTENT_TYPE', 'CONTENT_LENGTH'])) {
+            $default = $this->getServer($key, $default);
+        }
+
+        return $this->getServer('HTTP_' . $key, $default);
     }
 
     /**

--- a/var/Typecho/Request.php
+++ b/var/Typecho/Request.php
@@ -367,10 +367,7 @@ class Request
      */
     public function getContentType(): ?string
     {
-        return $this->getServer(
-            'CONTENT_TYPE',
-            $this->getServer('HTTP_CONTENT_TYPE')
-        );
+        return $this->getHeader('Content-Type');
     }
 
     /**


### PR DESCRIPTION
## 背景

PHP 作为 CGI 脚本运行时，若接收到非空 body 的请求，根据 [RFC 3875 - The Common Gateway Interface (CGI) Version 1.1](https://datatracker.ietf.org/doc/rfc3875/)，会有以下行为：

1. HTTP header 中的 `Content-Type` 和 `Content-Length` header 会被赋值到 `$_SERVER['CONTENT_TYPE']` 以及 `$_SERVER['CONTENT_LENGTH']`
2. 同时 `$_SERVER['HTTP_CONTENT_TYPE']` 和 `$_SERVER['HTTP_CONTENT_LENGTH']` 不一定被赋值（对接不同的 sapi，比如 apache 或者 nginx，可能会有不同的行为）

## 问题影响

- `Typecho\Request::getInstance()->getHeader('Content-Type')` 可能获取不到 `Content-Type` header
- <del>`Typecho\Request::getInstance()->isJson()` 可能返回不正确的值（由于获取不到 `Content-Type` header）</del>
- <del>`Typecho\Request::getInstance()->get('@json')` 可能错误地返回一个空值（由于 `isJson` 判断问题）</del>

因此，`Typecho\Request->getHeader` 函数需要对这两个 header 做额外处理，以解决上述问题。

## 复现

使用以下脚本进行复现

```php
<?php
function dump_server_value($key) {
    if (isset($_SERVER[$key])) {
        echo '$_SERVER["', $key, '"]: ';
        var_dump($_SERVER[$key]);
    } else {
        echo '$_SERVER["', $key, '"] not set.', "\n";
    }
}

echo "php version: ", phpversion(), "\n";
echo "php sapi name: ", php_sapi_name(), "\n";

dump_server_value('CONTENT_TYPE');
dump_server_value('CONTENT_LENGTH');

dump_server_value('HTTP_CONTENT_TYPE');
dump_server_value('HTTP_CONTENT_LENGTH');
```

1. PHP 8.3.1 & Apache

```
FROM php:8.3.1-apache

COPY index.php /var/www/html/index.php

CMD sleep 0.1 && \
    apache2-foreground & \
    sleep 2 && \
    curl -X GET "http://localhost/?method=get" && \
    curl -X POST "http://localhost/?method=post&with=body" -H "Content-Type: application/json" -d '{"hello": "world"}' && \
    curl -X PUT "http://localhost/?method=put&with=body" -H "Content-Type: application/json" -d '{"hello": "world"}' && \
    curl -X GET "http://localhost/?method=get&with=body" -H "Content-Type: application/json" -d '{"hello": "world"}' && \
    wait
```

输出如下：

```
127.0.0.1 - - [12/Jan/2024:11:25:58 +0000] "GET /?method=get HTTP/1.1" 200 396 "-" "curl/7.88.1"
php version: 8.3.1
php sapi name: apache2handler
$_SERVER["CONTENT_TYPE"] not set.
$_SERVER["CONTENT_LENGTH"] not set.
$_SERVER["HTTP_CONTENT_TYPE"] not set.
$_SERVER["HTTP_CONTENT_LENGTH"] not set.

127.0.0.1 - - [12/Jan/2024:11:25:58 +0000] "POST /?method=post&with=body HTTP/1.1" 200 425 "-" "curl/7.88.1"
php version: 8.3.1
php sapi name: apache2handler
$_SERVER["CONTENT_TYPE"]: string(16) "application/json"
$_SERVER["CONTENT_LENGTH"]: string(2) "18"
$_SERVER["HTTP_CONTENT_TYPE"] not set.
$_SERVER["HTTP_CONTENT_LENGTH"] not set.

127.0.0.1 - - [12/Jan/2024:11:25:58 +0000] "PUT /?method=put&with=body HTTP/1.1" 200 425 "-" "curl/7.88.1"
php version: 8.3.1
php sapi name: apache2handler
$_SERVER["CONTENT_TYPE"]: string(16) "application/json"
$_SERVER["CONTENT_LENGTH"]: string(2) "18"
$_SERVER["HTTP_CONTENT_TYPE"] not set.
$_SERVER["HTTP_CONTENT_LENGTH"] not set.

127.0.0.1 - - [12/Jan/2024:11:25:58 +0000] "GET /?method=get&with=body HTTP/1.1" 200 425 "-" "curl/7.88.1"
php version: 8.3.1
php sapi name: apache2handler
$_SERVER["CONTENT_TYPE"]: string(16) "application/json"
$_SERVER["CONTENT_LENGTH"]: string(2) "18"
$_SERVER["HTTP_CONTENT_TYPE"] not set.
$_SERVER["HTTP_CONTENT_LENGTH"] not set.
```

2. PHP 8.3.1 & Nginx

```
FROM php:8.3.1-fpm

RUN apt-get update && apt-get install -y nginx

COPY index.php /var/www/html/index.php

RUN echo 'server {\n\
    listen 80 default_server;\n\
    server_name _;\n\
    root /var/www/html;\n\
    index index.php;\n\
    location / {\n\
        try_files $uri $uri/ =404;\n\
    }\n\
    location ~ \.php$ {\n\
        include fastcgi_params;\n\
        fastcgi_pass 127.0.0.1:9000;\n\
        fastcgi_index index.php;\n\
        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;\n\
    }\n\
}' > /etc/nginx/sites-available/default

CMD sleep 0.1 && \
    php-fpm & service nginx start && \
    sleep 2 && \
    curl -X GET "http://localhost/?method=get" && \
    curl -X POST "http://localhost/?method=post&with=body" -H "Content-Type: application/json" -d '{"hello": "world"}' && \
    curl -X PUT "http://localhost/?method=put&with=body" -H "Content-Type: application/json" -d '{"hello": "world"}' && \
    curl -X GET "http://localhost/?method=get&with=body" -H "Content-Type: application/json" -d '{"hello": "world"}' && \
    wait
```

输出如下：

```
127.0.0.1 -  12/Jan/2024:11:36:50 +0000 "GET /index.php" 200
php version: 8.3.1
php sapi name: fpm-fcgi
$_SERVER["CONTENT_TYPE"]: string(0) ""
$_SERVER["CONTENT_LENGTH"]: string(0) ""
$_SERVER["HTTP_CONTENT_TYPE"] not set.
$_SERVER["HTTP_CONTENT_LENGTH"] not set.

127.0.0.1 -  12/Jan/2024:11:36:50 +0000 "POST /index.php" 200
php version: 8.3.1
php sapi name: fpm-fcgi
$_SERVER["CONTENT_TYPE"]: string(16) "application/json"
$_SERVER["CONTENT_LENGTH"]: string(2) "18"
$_SERVER["HTTP_CONTENT_TYPE"]: string(16) "application/json"
$_SERVER["HTTP_CONTENT_LENGTH"]: string(2) "18"

<html>
<head><title>405 Not Allowed</title></head>
<body>
<center><h1>405 Not Allowed</h1></center>
<hr><center>nginx/1.22.1</center>
</body>
</html>

127.0.0.1 -  12/Jan/2024:11:36:50 +0000 "GET /index.php" 200
php version: 8.3.1
php sapi name: fpm-fcgi
$_SERVER["CONTENT_TYPE"]: string(16) "application/json"
$_SERVER["CONTENT_LENGTH"]: string(2) "18"
$_SERVER["HTTP_CONTENT_TYPE"]: string(16) "application/json"
$_SERVER["HTTP_CONTENT_LENGTH"]: string(2) "18"
```

## 改动

`Typecho\Request->getHeader` 函数在获取 `Content-Type` 和 `Content-Length` 两个 header 之一时，按以下顺序尝试获取：

1. 尝试从 `$_SERVER['HTTP_CONTENT_TYPE']` / `$_SERVER['HTTP_CONTENT_LENGTH']` 获取
2. 尝试从 `$_SERVER['CONTENT_TYPE']` / `$_SERVER['CONTENT_LENGTH']` 获取（← 增加这一步骤）
3. 返回 `$default`

## 参考

1. https://www.php.net/manual/en/reserved.variables.server.php - 指出 `$_SERVER` 中的字段定义除了在该文档中列出的字段以外，还遵循 [RFC 3875](https://datatracker.ietf.org/doc/rfc3875/) 中定义的部分字段
3. https://www.php.net/manual/en/install.unix.commandline.php - 指出 `CONTENT_LENGTH` 和 `CONTENT_TYPE` 属于 `$_SERVER` 下的内置定义字段（not `vendor extensions`）
4. [RFC 3875](https://datatracker.ietf.org/doc/rfc3875/) 
   - 4.1.2. 和 4.1.3. 定义了 `CONTENT_LENGTH` 和 `CONTENT_TYPE` 两个字段；
   - 4.1.18. 指出当 `Content-Type` 和 `Content-Length` 这两个 HTTP Header 可以从其他字段（即 `CONTENT_LENGTH` 和 `CONTENT_TYPE`）取得时，CGI 服务器应当将它们从 `HTTP_*` 这些 HTTP 协议字段（即 `HTTP_CONTENT_LENGTH` 和 `HTTP_CONTENT_TYPE`）中移除
5. https://bugs.php.net/66606 - 指出 php 设置了 `$_SERVER['HTTP_CONTENT_TYPE']` 但没有设置 `$_SERVER['CONTENT_TYPE']` 是不符合预期的行为