### PR TITLE
修复typecho在二级目录下，使用伪静态url中不包含二级路径情况下的问题

### DIFF
--- a/var/Typecho/Request.php
+++ b/var/Typecho/Request.php
@@ -680,6 +680,14 @@ class Request
             // out of baseUrl. $pos !== 0 makes sure it is not matching a value
             // from PATH_INFO or QUERY_STRING
             $baseUrl = substr($requestUri, 0, $pos + strlen($baseUrl));
+        } else {
+            // 找 $baseUrl 和 $requestUri 之间的共同部分
+            // 处理目录在二级目录下
+            // 并且定义了ROOT_URL不包含路径信息，此时baseUrl也不能包含路径信息
+            $arr1 = array_filter(explode("/", $baseUrl));
+            $arr2 = array_filter(explode("/", $requestUri));
+            $commonArr = array_intersect($arr1, $arr2);
+            $finalBaseUrl = empty($commonArr) ? "" : '/' . reset($commonArr);
         }
 
         return ($this->baseUrl = (null === $finalBaseUrl) ? rtrim($baseUrl, '/') : $finalBaseUrl);

--- a/var/Typecho/Request.php
+++ b/var/Typecho/Request.php
@@ -669,21 +669,9 @@ class Request
         } elseif (0 === strpos($requestUri, dirname($baseUrl))) {
             // directory portion of $baseUrl matches
             $finalBaseUrl = rtrim(dirname($baseUrl), '/');
-        } elseif (!strpos($requestUri, basename($baseUrl))) {
-            // no match whatsoever; set it blank
-            $finalBaseUrl = '';
-        } elseif (
-            (strlen($requestUri) >= strlen($baseUrl))
-            && ((false !== ($pos = strpos($requestUri, $baseUrl))) && ($pos !== 0))
-        ) {
-            // If using mod_rewrite or ISAPI_Rewrite strip the script filename
-            // out of baseUrl. $pos !== 0 makes sure it is not matching a value
-            // from PATH_INFO or QUERY_STRING
-            $baseUrl = substr($requestUri, 0, $pos + strlen($baseUrl));
         } else {
-            // 找 $baseUrl 和 $requestUri 之间的共同部分
-            // 处理目录在二级目录下
-            // 并且定义了ROOT_URL不包含路径信息，此时baseUrl也不能包含路径信息
+            // when using url rewrite, the starting positions of $baseUrl and $requestUri may not match.
+            // In this case, find the common part of both as $finalBaseUrl.
             $arr1 = array_filter(explode("/", $baseUrl));
             $arr2 = array_filter(explode("/", $requestUri));
             $commonArr = array_intersect($arr1, $arr2);

--- a/var/Widget/Options.php
+++ b/var/Widget/Options.php
@@ -424,7 +424,9 @@ class Options extends Base
         if (defined('__TYPECHO_ADMIN__')) {
             /** 识别在admin目录中的情况 */
             $adminDir = '/' . trim(defined('__TYPECHO_ADMIN_DIR__') ? __TYPECHO_ADMIN_DIR__ : '/admin/', '/');
-            $rootUrl = substr($rootUrl, 0, - strlen($adminDir));
+            if (strpos($rootUrl, $adminDir) !== false) {
+                $rootUrl = substr($rootUrl, 0, -strlen($adminDir));
+            }
         }
 
         return $rootUrl;


### PR DESCRIPTION
## 摘要

**场景：**

当 Typecho 安装在子目录（例如 `/blog`）下时，通常需要访问 `xxxx.com/blog/yyy`。通过地址重写，也可以让 `xxxx.com/yyy` 实际访问 `/blog/yyy`，但此时请求 URL 与真实资源路径的起始位置不一致。

**存在的问题：**

- `getBaseUrl()` 返回真实资源路径，导致后台访问时重定向到 `xxx.com/blog/admin`，而不是 `xxx.com/admin`。
- 手动定义 `__TYPECHO_ROOT_URL__` 时，`___rootUrl()` 无条件移除 `/admin` 长度，可能返回残缺的 root URL。
- 请求 `xxx.com/index.php/action/xxx?ref=xxxx` 时，`requestUri` 与 `baseUrl` 起始位置不匹配，导致 `getPathInfo()` 返回错误结果。

**修复内容：**

- 调整 `Request::getBaseUrl()`：当 URL 重写导致路径起始位置不一致时，基于请求 URL 和资源 URL 的公共路径计算 base URL。
- 调整 `Options::___rootUrl()`：仅当 root URL 包含后台目录时才移除后台目录路径。
- 修改后无需手动定义 `__TYPECHO_ROOT_URL__`，root URL 可与当前请求地址正确关联，并避免后台重定向到包含 `/blog` 的路径。

**附 Apache 配置：**

```apache
<IfModule mod_rewrite.c>
RewriteEngine On

# 不带子目录路径重写到子目录上
RewriteCond %{REQUEST_URI} !^/blog/
RewriteRule ^(.*)$ blog/$1 [QSA]

# 伪静态
RewriteCond %{REQUEST_FILENAME} !-f
RewriteCond %{REQUEST_FILENAME} !-d
RewriteRule ^(.*)$ /blog/index.php/$1 [L]

</IfModule>
```

## 测试

未运行（未请求）。