### PR TITLE
Fix timezone error in XmlRpc

### DIFF
--- a/var/IXR/Date.php
+++ b/var/IXR/Date.php
@@ -9,17 +9,19 @@ namespace IXR;
  */
 class Date
 {
-    private int $year;
+    private string $year;
 
-    private int $month;
+    private string $month;
 
-    private int $day;
+    private string $day;
 
-    private int $hour;
+    private string $hour;
 
-    private int $minute;
+    private string $minute;
 
-    private int $second;
+    private string $second;
+
+    private string $timezone;
 
     /**
      * @param int|string $time
@@ -39,12 +41,13 @@ class Date
      */
     private function parseTimestamp(int $timestamp)
     {
-        $this->year = intval(date('Y', $timestamp));
-        $this->month = intval(date('m', $timestamp));
-        $this->day = intval(date('d', $timestamp));
-        $this->hour = intval(date('H', $timestamp));
-        $this->minute = intval(date('i', $timestamp));
-        $this->second = intval(date('s', $timestamp));
+        $this->year = gmdate('Y', $timestamp);
+        $this->month = gmdate('m', $timestamp);
+        $this->day = gmdate('d', $timestamp);
+        $this->hour = gmdate('H', $timestamp);
+        $this->minute = gmdate('i', $timestamp);
+        $this->second = gmdate('s', $timestamp);
+        $this->timezone = '';
     }
 
     /**
@@ -58,6 +61,7 @@ class Date
         $this->hour = substr($iso, 9, 2);
         $this->minute = substr($iso, 12, 2);
         $this->second = substr($iso, 15, 2);
+        $this->timezone = substr($iso, 17);
     }
 
     /**
@@ -65,7 +69,7 @@ class Date
      */
     public function getIso(): string
     {
-        return $this->year . $this->month . $this->day . 'T' . $this->hour . ':' . $this->minute . ':' . $this->second;
+        return $this->year . $this->month . $this->day . 'T' . $this->hour . ':' . $this->minute . ':' . $this->second . $this->timezone;
     }
 
     /**

--- a/var/Widget/XmlRpc.php
+++ b/var/Widget/XmlRpc.php
@@ -576,7 +576,7 @@ class XmlRpc extends Contents implements ActionInterface, Hook
         while ($pages->next()) {
             $pageStructs[] = [
                 'dateCreated'      => new Date($this->options->timezone + $pages->created),
-                'date_created_gmt' => new Date($this->options->timezone + $pages->created),
+                'date_created_gmt' => new Date($pages->created),
                 'page_id'          => $pages->cid,
                 'page_title'       => $pages->title,
                 'page_parent_id'   => '0',
@@ -945,7 +945,7 @@ class XmlRpc extends Contents implements ActionInterface, Hook
         }
 
         return [
-            'date_created_gmt' => new Date($this->options->timezone + $comment->created),
+            'date_created_gmt' => new Date($comment->created),
             'user_id'          => $comment->authorId,
             'comment_id'       => $comment->coid,
             'parent'           => $comment->parent,
@@ -999,7 +999,7 @@ class XmlRpc extends Contents implements ActionInterface, Hook
 
         while ($comments->next()) {
             $commentsStruct[] = [
-                'date_created_gmt' => new Date($this->options->timezone + $comments->created),
+                'date_created_gmt' => new Date($comments->created),
                 'user_id'          => $comments->authorId,
                 'comment_id'       => $comments->coid,
                 'parent'           => $comments->parent,
@@ -1174,7 +1174,7 @@ class XmlRpc extends Contents implements ActionInterface, Hook
         while ($attachments->next()) {
             $attachmentsStruct[] = [
                 'attachment_id'    => $attachments->cid,
-                'date_created_gmt' => new Date($this->options->timezone + $attachments->created),
+                'date_created_gmt' => new Date($attachments->created),
                 'parent'           => $attachments->parent,
                 'link'             => $attachments->attachment->url,
                 'title'            => $attachments->title,
@@ -1205,7 +1205,7 @@ class XmlRpc extends Contents implements ActionInterface, Hook
 
         return [
             'attachment_id'    => $attachment->cid,
-            'date_created_gmt' => new Date($this->options->timezone + $attachment->created),
+            'date_created_gmt' => new Date($attachment->created),
             'parent'           => $attachment->parent,
             'link'             => $attachment->attachment->url,
             'title'            => $attachment->title,
@@ -1417,7 +1417,7 @@ class XmlRpc extends Contents implements ActionInterface, Hook
                 'userid'           => $posts->authorId,
                 'postid'           => $posts->cid,
                 'title'            => $posts->title,
-                'date_created_gmt' => new Date($this->options->timezone + $posts->created)
+                'date_created_gmt' => new Date($posts->created)
             ];
         }
 


### PR DESCRIPTION
```
                'date_modified'          => new Date($this->options->timezone + $posts->modified),
                'date_modified_gmt'      => new Date($posts->modified),
```

未修正之前在`IXR\Date`中使用的`date`计算日期是依赖服务器时区，WP中已后缀`_gmt`为格林威治时间，`date_modified_gmt`不再是格林威治时间。

并且本地时间`date_modified`、格林威治时间`date_modified_gmt`因为快了$timezone时区，所以两个时间永远不正确。