### PR TITLE
feat: avatar default use weavatar source

### DIFF
--- a/install.php
+++ b/install.php
@@ -14,7 +14,7 @@ if (!file_exists(dirname(__FILE__) . '/config.inc.php')) {
     define('__TYPECHO_ADMIN_DIR__', '/admin/');
 
     // gravatar prefix
-    define('__TYPECHO_GRAVATAR_PREFIX__', 'https://weavatar.com');
+    define('__TYPECHO_GRAVATAR_PREFIX__', 'https://weavatar.com/avatar/');
 
     // register autoload
     require_once __TYPECHO_ROOT_DIR__ . '/var/Typecho/Common.php';
@@ -417,7 +417,7 @@ define('__TYPECHO_THEME_DIR__', '/usr/themes');
 define('__TYPECHO_ADMIN_DIR__', '/admin/');
 
 // gravatar prefix
-define('__TYPECHO_GRAVATAR_PREFIX__', 'https://weavatar.com');
+define('__TYPECHO_GRAVATAR_PREFIX__', 'https://weavatar.com/avatar/');
 
 // register autoload
 require_once __TYPECHO_ROOT_DIR__ . '/var/Typecho/Common.php';

--- a/install.php
+++ b/install.php
@@ -13,6 +13,9 @@ if (!file_exists(dirname(__FILE__) . '/config.inc.php')) {
     // admin directory (relative path)
     define('__TYPECHO_ADMIN_DIR__', '/admin/');
 
+    // gravatar prefix
+    define('__TYPECHO_GRAVATAR_PREFIX__', 'https://weavatar.com');
+
     // register autoload
     require_once __TYPECHO_ROOT_DIR__ . '/var/Typecho/Common.php';
 
@@ -412,6 +415,9 @@ define('__TYPECHO_THEME_DIR__', '/usr/themes');
 
 // admin directory (relative path)
 define('__TYPECHO_ADMIN_DIR__', '/admin/');
+
+// gravatar prefix
+define('__TYPECHO_GRAVATAR_PREFIX__', 'https://weavatar.com');
 
 // register autoload
 require_once __TYPECHO_ROOT_DIR__ . '/var/Typecho/Common.php';

--- a/var/Typecho/Common.php
+++ b/var/Typecho/Common.php
@@ -854,7 +854,7 @@ EOF;
             }
 
             if (!empty($mail)) {
-                $url .= md5(strtolower(trim($mail)));
+                $url .= hash('sha256', strtolower(trim($mail)));
             }
 
             $url .= '?s=' . $size;


### PR DESCRIPTION
Gravatar 的域名（secure.gravatar.com）在国内已被污染无法正常访问很久了，考虑到 Typecho 用户群体主要都在国内，因此建议默认配置头像源以解决此问题，另外还修改了哈希算法为 SHA256，Gravatar 目前[推荐](https://docs.gravatar.com/api/avatars/hash/)此算法。

默认配置的 [WeAvatar](https://weavatar.com) 是我们维护的新一代头像服务，支持 WEBP、QUIC 、AI 审核在内的多种新特性，且有完善的[监控系统](https://status.haozi.net/)和多条备份线路以保证高可用。