### PR TITLE
Fix: fix preg_match parameter#2 $subject is null deprecated issue

### DIFF
--- a/var/Typecho/I18n/GetText.php
+++ b/var/Typecho/I18n/GetText.php
@@ -394,7 +394,8 @@ class GetText
             } else {
                 $header = $this->getTranslationString(0);
             }
-            if (preg_match("/plural\-forms: ([^\n]*)\n/i", $header, $regs)) {
+            
+            if (!is_null($header) && preg_match("/plural\-forms: ([^\n]*)\n/i", $header, $regs)) {
                 $expr = $regs[1];
             } else {
                 $expr = "nplurals=2; plural=n == 1 ? 0 : 1;";


### PR DESCRIPTION
修复了 #1797 中提到的PHP 8.3下有翻译情况下因为`$header`是`null`的时候调用`preg_match`报`deprecated`的问题