### PR TITLE
修复和改进 I18n 的多语言文件加载逻辑

### DIFF
--- a/var/Typecho/I18n.php
+++ b/var/Typecho/I18n.php
@@ -139,7 +139,10 @@ class I18n
      */
     public static function addLang(string $lang)
     {
-        self::$loaded->addFile($lang);
+        self::init();
+        if (self::$loaded) {
+            self::$loaded->addFile($lang);
+        }
     }
 
     /**

--- a/var/Typecho/I18n/GetText.php
+++ b/var/Typecho/I18n/GetText.php
@@ -110,6 +110,7 @@ class GetText
     public function translate($string, ?int &$num): string
     {
         if ($this->short_circuit) {
+            $num = -1;
             return $string;
         }
         $this->loadTables();
@@ -117,8 +118,10 @@ class GetText
         if ($this->enable_cache) {
             // Caching enabled, get translated string from cache
             if (array_key_exists($string, $this->cache_translations)) {
+                $num = 0;
                 return $this->cache_translations[$string];
             } else {
+                $num = -1;
                 return $string;
             }
         } else {
@@ -147,6 +150,7 @@ class GetText
         $number = intval($number);
 
         if ($this->short_circuit) {
+            $num = -1;
             if ($number != 1) {
                 return $plural;
             } else {
@@ -160,11 +164,12 @@ class GetText
         // this should contains all strings separated by NULLs
         $key = $single . chr(0) . $plural;
 
-
         if ($this->enable_cache) {
             if (!array_key_exists($key, $this->cache_translations)) {
+                $num = -1;
                 return ($number != 1) ? $plural : $single;
             } else {
+                $num = 0;
                 $result = $this->cache_translations[$key];
                 $list = explode(chr(0), $result);
                 return $list[$select] ?? '';

--- a/var/Typecho/I18n/GetTextMulti.php
+++ b/var/Typecho/I18n/GetTextMulti.php
@@ -74,8 +74,6 @@ class GetTextMulti
      */
     public function ngettext(string $single, string $plural, int $number): string
     {
-        $count = - 1;
-
         foreach ($this->handlers as $handler) {
             $string = $handler->ngettext($single, $plural, $number, $count);
             if (- 1 != $count) {


### PR DESCRIPTION
该 Pull Request 旨在解决 I18n 实现中的两个关键问题：

1. **多语言文件加载问题**  

    当前实现中，`GetTextMulti::translate` 遍历所有语言文件的 handler，期望通过 `$count` 判断是否找到翻译。若 `$count != -1` 则终止循环，否则继续检查后续文件。
    
    而不论是被标记短路 (`short_circuit`) 或是启用缓存 (`enable_cache`) 的情况下，`GetText::translate` 和 `GetText::ngettext` 方法都未正确设置 `$num` 的值，导致 `GetTextMulti` 在遍历翻译文件时提前终止。
    
    修改后，在这两个条件中 `$num` 会被显式设置为 `-1`（未找到）或 `0`（找到），确保能够通过 `$count` 判断是否找到翻译，使得所有翻译文件都能被正确遍历。

2. **翻译文件加载时机问题**  
    
    在加载主题的 `function.php` 时，`I18n` 可能尚未初始化，而 `I18n::init` 是私有方法，无法直接调用。针对此问题参考了 `I18n::translate` 和 `I18n::ngettext` 的实现，对 `I18n::addLang` 进行了修改。
    
    修改后，在 `I18n::addLang` 中会尝试自动调用 `init()`，并且再确认在未能载入的情况下不进一步尝试调用 `GetTextMulti::addFile`。

修改后，对于主题或是插件的开发者，都可以经由下列方法实现 I18n（以主题为例）：

- **通过 `\Typecho\I18n::addLang`**

    在主题的 `function.php` 中，可以通过：
    ```PHP
    \Typecho\I18n::getLang()
    ```
    获取到当前挂载的语言文件，如果其值存在则证明用户的语言设置为了 `zh_CN` 之外的值，那么就可以通过 `basename` 进一步获取到形如 `en_US.mo` 的内容，开发者可以自行判断是否存在相应的 I18n 支持，并且通过：
    ```PHP
    \Typecho\I18n::addLang(dirname(__FILE__) . '/lang/en_US.mo');
    ```
    这样的方法进行挂载。

- **通过 `\Utils\Helper::lang`**

    ```PHP
    \Utils\Helper::lang('../../usr/themes/<theme_folder>/');
    ```
    该方法会自行寻找 `<theme_folder>/lang` 目录下是否存在用户所选语言的 `.mo` 文件并进行挂载。