### PR TITLE
解决loginAction的网址未适配伪静态问题

### DIFF
--- a/var/Widget/Options.php
+++ b/var/Widget/Options.php
@@ -611,7 +611,7 @@ class Options extends Base
             Router::url(
                 'do',
                 ['action' => 'login', 'widget' => 'Login'],
-                Common::url('index.php', $this->rootUrl)
+                $this->index
             )
         );
     }


### PR DESCRIPTION
解决伪静态下`loginAction`的网址仍携带`index.php`的问题（部分环境下开启伪静态后携带`index.php`会导致登录报错）