### PR TITLE
后台登录页 PHP 8.1+ 的严格类型更新适配

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -4,7 +4,7 @@ include 'common.php';
 if ($user->hasLogin()) {
     $response->redirect($options->adminUrl);
 }
-$rememberName = htmlspecialchars(\Typecho\Cookie::get('__typecho_remember_name', ''));
+$rememberName = htmlspecialchars((string) (\Typecho\Cookie::get('__typecho_remember_name') ?? ''), ENT_QUOTES);
 \Typecho\Cookie::delete('__typecho_remember_name');
 
 $bodyClass = 'body-100';


### PR DESCRIPTION
Typecho\Cookie::get() 可能返回 null，而 PHP 8.1 之后， htmlspecialchars() 不接受 null。使用 PHP 8.1 + 可能导致
Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in admin/login.php on line 7
的安全警告，需要使用空的string类型代替null。