### PR TITLE
修复 PDO::MYSQL_ATTR_USE_BUFFERED_QUERY 的弃用警告

### DIFF
--- a/var/Typecho/Db/Adapter/Pdo/Mysql.php
+++ b/var/Typecho/Db/Adapter/Pdo/Mysql.php
@@ -73,7 +73,14 @@ class Mysql extends Pdo
             $config->password,
             $options
         );
-        $pdo->setAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
+
+        if (class_exists('\Pdo\Mysql')) {
+            // 新版本写法
+            $pdo->setAttribute(\Pdo\Mysql::ATTR_USE_BUFFERED_QUERY, true);
+        } else {
+            // 兼容旧版本
+            $pdo->setAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
+        }
 
         if ($config->charset) {
             $pdo->exec("SET NAMES '{$config->charset}'");


### PR DESCRIPTION
优先使用 \Pdo\Mysql::ATTR_USE_BUFFERED_QUERY，降级兼容旧常量，消除 Deprecated 警告