### PR TITLE
fix: 修复归档Feed属性未初始化报错 Fix #1925

### DIFF
--- a/var/Widget/Archive.php
+++ b/var/Widget/Archive.php
@@ -95,21 +95,21 @@ class Archive extends Contents
      *
      * @var string
      */
-    private string $archiveFeedUrl;
+    private string $archiveFeedUrl = '';
 
     /**
      * RSS 1.0聚合地址
      *
      * @var string
      */
-    private string $archiveFeedRssUrl;
+    private string $archiveFeedRssUrl = '';
 
     /**
      * ATOM 聚合地址
      *
      * @var string
      */
-    private string $archiveFeedAtomUrl;
+    private string $archiveFeedAtomUrl = '';
 
     /**
      * 本页关键字


### PR DESCRIPTION
为 $archiveFeedUrl/$archiveFeedRssUrl/$archiveFeedAtomUrl 补充空字符串默认值， 解决 PHP 7.4+ 类型化属性未初始化访问的报错问题。

Close #1925