### PR TITLE
fix: 修复 PHP 8.1+ 下 strlen(null) 废弃警告

### DIFF
--- a/var/Widget/Base/Contents.php
+++ b/var/Widget/Base/Contents.php
@@ -593,7 +593,7 @@ class Contents extends Base implements QueryInterface, RowFilterInterface, Prima
     protected function ___hidden(): bool
     {
         if (
-            strlen($this->password) > 0 &&
+            !empty($this->password) > 0 &&
             $this->password !== Cookie::get('protectPassword_' . $this->cid) &&
             $this->authorId != $this->user->uid &&
             !$this->user->pass('editor', true)


### PR DESCRIPTION
遇到这个报错
``` html
<b>Deprecated</b>:  strlen(): Passing null to parameter #1 ($string) of type string is deprecated in <b>/www/wwwroot/blog.pennote.cn/var/Widget/Base/Contents.php</b> on line <b>596</b><br />
```

数据库的`password`字段是 NULL，而 strlen($this->password) 在 PHP 8.1+ 会报 Deprecated 警告（因为传了 null 给 strlen）。

解决办法是把 `var/Widget/Base/Contents.php` 第596行
从
``` php
strlen($this->password) > 0 &&
```
改成
``` php
!empty($this->password) &&
```