### PR TITLE
文章发布页面删除默认勾选分类

### DIFF
--- a/admin/write-post.php
+++ b/admin/write-post.php
@@ -101,8 +101,7 @@ $post = \Widget\Contents\Post\Edit::alloc()->prepare();
                             <?php while ($category->next()): ?>
                                 <li><?php echo str_repeat('&nbsp;&nbsp;&nbsp;&nbsp;', $category->levels); ?><input
                                         type="checkbox" id="category-<?php $category->mid(); ?>"
-                                        value="<?php $category->mid(); ?>" name="category[]"
-                                        <?php if (in_array($category->mid, $categories)): ?>checked="true"<?php endif; ?>/>
+                                        value="<?php $category->mid(); ?>" name="category[]"/>
                                     <label
                                         for="category-<?php $category->mid(); ?>"><?php $category->name(); ?></label>
                                 </li>


### PR DESCRIPTION
文章发布页面删除默认勾选分类，默认勾选了反而增加用户使用成本，因为需要手动取消勾选在勾选别的分类。

用户没选择任何分类时，发布文章后也会自动将默认分类作为文章分类，所以没必要直接默认勾选