### PR TITLE
Fix TypeError in ___text() with empty search results

### DIFF
--- a/var/Widget/Base/Contents.php
+++ b/var/Widget/Base/Contents.php
@@ -574,7 +574,8 @@ class Contents extends Base implements QueryInterface, RowFilterInterface, Prima
                 '</form>';
         }
 
-        return $this->isMarkdown ? substr($this->row['text'], 15) : $this->row['text'];
+        $text = $this->row['text'] ?? '';
+		return $this->isMarkdown ? substr($text, 15) : $text;
     }
 
     /**


### PR DESCRIPTION
When using PostgreSQL, $this->row['text'] may be null if a search returns no results. Cast to empty string to satisfy the declared string return type under PHP 8+.

### Environment / Testing

This issue was reproduced and tested using PostgreSQL as the database backend.

Under PostgreSQL, fields such as `text` are preserved as `NULL` when no row is available
(e.g. empty search results), unlike some MySQL configurations where `NULL` may be implicitly
converted to an empty string.

With PHP 8+ strict return type enforcement, returning `null` from a method declared as
`string` results in a fatal `TypeError`.

### Rationale

`___text()` is declared to return `string`, but it may currently return `null` when
`$this->row['text']` is not set. This can happen legitimately when:

- A search query returns no results
- The theme still calls `$this->excerpt()` / `$this->content()`

Returning an empty string in this case is safe, consistent with previous behavior,
and aligns with the method’s return type contract.

This change improves robustness across database backends (PostgreSQL / MySQL)
and ensures compatibility with PHP 8+ without altering existing content behavior.

Component | Behavior
-- | --
MySQL | Implicit NULL → ''
PostgreSQL | NULL is NULL

### Reproduction

1. Use PHP 8+
2. Perform a search query that matches no content
3. Theme calls `$this->excerpt()` or `$this->content()`
4. Fatal TypeError is thrown

```
Widget\Base\Contents::___text(): Return value must be of type string, null returned
TypeError: Widget\Base\Contents::___text(): Return value must be of type string, null returned in /usr/local/www/wwwroot/blog/var/Widget/Base/Contents.php:577
Stack trace:
#0 /usr/local/www/wwwroot/blog/var/Typecho/Widget.php(462): Widget\Base\Contents->___text()
#1 /usr/local/www/wwwroot/blog/var/Widget/Base/Contents.php(852): Typecho\Widget->__get()
#2 /usr/local/www/wwwroot/blog/var/Typecho/Widget.php(462): Widget\Base\Contents->___content()
#3 /usr/local/www/wwwroot/blog/var/Widget/Base/Contents.php(783): Typecho\Widget->__get()
#4 /usr/local/www/wwwroot/blog/var/Typecho/Widget.php(462): Widget\Base\Contents->___excerpt()
#5 /usr/local/www/wwwroot/blog/var/Widget/Base/Contents.php(396): Typecho\Widget->__get()
#6 /usr/local/www/wwwroot/blog/usr/themes/PureSuck_mxd/header.php(14): Widget\Base\Contents->excerpt()
#7 /usr/local/www/wwwroot/blog/var/Widget/Archive.php(1308): require('...')
#8 /usr/local/www/wwwroot/blog/usr/themes/PureSuck_mxd/archive.php(2): Widget\Archive->need()
#9 /usr/local/www/wwwroot/blog/var/Widget/Archive.php(1390): require_once('...')
#10 /usr/local/www/wwwroot/blog/var/Typecho/Router.php(88): Widget\Archive->render()
#11 /usr/local/www/wwwroot/blog/index.php(23): Typecho\Router::dispatch()
#12 {main}
```

**Similar defensive handling may also be applicable to other
`___*()` accessors that directly return nullable row fields.**
