### PR TITLE
给Widget\Menu类的$title添加默认值

### DIFF
--- a/var/Widget/Menu.php
+++ b/var/Widget/Menu.php
@@ -31,7 +31,7 @@ class Menu extends Base
      * 当前菜单标题
      * @var string
      */
-    public string $title;
+    public string $title = '';
 
     /**
      * 当前增加项目链接


### PR DESCRIPTION
给Widget\Menu类的$title添加默认值，以此修复后台访问地址是/admin而非/admin/index.php时的 “Typed property Widget\Menu::$title must not be accessed before initialization” 错误提示