### PR TITLE
Add recursive parent category retrieval in ___directory

### DIFF
--- a/var/Widget/Base/Metas.php
+++ b/var/Widget/Base/Metas.php
@@ -210,7 +210,23 @@ class Metas extends Base implements QueryInterface, RowFilterInterface, PrimaryK
      */
     protected function ___directory(): array
     {
-        return [];
+        $directory = [];
+        $parent = $this->parent;
+        // 递归向上查找所有父分类
+        while ($parent > 0) {
+            $parentCategory = $this->db->fetchRow($this->db->select()
+                ->from('table.metas')
+                ->where('mid = ?', $parent)
+                ->where('type = ?', $this->type)); // 确保是同类型（category/tag）
+            if ($parentCategory) {
+                array_unshift($directory, $parentCategory['slug']);
+                $parent = $parentCategory['parent'];
+            } else {
+                break;
+            }
+        }
+        $directory[] = $this->slug;
+        return $directory;
     }
 
     /**


### PR DESCRIPTION
Implemented recursive parent category lookup in ___directory method.

修复伪静态分类链接设置为/{directory}时，使用`$metas=Helper::widgetById('Metas',$mid);`获取指定mid的分类信息时，获取不到分类链接问题