### PR TITLE
Add Clear-Site-Data header to response

### DIFF
--- a/var/Typecho/Widget/Response.php
+++ b/var/Typecho/Widget/Response.php
@@ -175,6 +175,7 @@ class Response
 
         $this->response->setStatus($isPermanently ? 301 : 302)
             ->setHeader('Location', $location)
+            ->setHeader('Clear-Site-Data','"prefetchCache", "prerenderCache"')
             ->respond();
     }
 


### PR DESCRIPTION
清理浏览器基于 Speculation Rules API‌  预取的、用于未来导航的资源，主要用于兼容用户开发的基于speculation rules加速后台页面的插件