### PR TITLE
Validate Referer host before redirecting in Response::goBack

### DIFF
--- a/var/Typecho/Widget/Response.php
+++ b/var/Typecho/Widget/Response.php
@@ -189,6 +189,11 @@ class Response
         //获取来源
         $referer = $this->request->getReferer();
 
+        // 验证来源主机必须与当前请求主机一致, 防止开放重定向 (CWE-601)
+        if (!empty($referer) && !$this->isSameOriginReferer($referer)) {
+            $referer = null;
+        }
+
         //判断来源
         if (!empty($referer)) {
             // ~ fix Issue 38
@@ -218,6 +223,49 @@ class Response
         } else {
             $this->redirect($default ?: '/');
         }
+    }
+
+    /**
+     * 判断 Referer 是否与当前请求同源.
+     *
+     * Referer 必须是绝对 URL, 且其 host 与当前请求 host 完全一致.
+     * 没有 host 的相对路径也视为同源.
+     *
+     * @param string $referer
+     * @return bool
+     */
+    private function isSameOriginReferer(string $referer): bool
+    {
+        $refererParts = @parse_url($referer);
+
+        // parse_url 失败 -> 视为不可信
+        if (!is_array($refererParts)) {
+            return false;
+        }
+
+        // 相对路径 (没有 host) -> 同源
+        if (empty($refererParts['host'])) {
+            return true;
+        }
+
+        $currentParts = @parse_url($this->request->getUrlPrefix() ?? '');
+        if (!is_array($currentParts) || empty($currentParts['host'])) {
+            return false;
+        }
+
+        // host 必须严格相等 (大小写不敏感)
+        if (strcasecmp($refererParts['host'], $currentParts['host']) !== 0) {
+            return false;
+        }
+
+        // 端口必须一致 (未指定端口按协议默认)
+        $refererPort = $refererParts['port'] ?? ($refererParts['scheme'] === 'https' ? 443 : 80);
+        $currentPort = $currentParts['port'] ?? (($currentParts['scheme'] ?? 'http') === 'https' ? 443 : 80);
+        if ($refererPort !== $currentPort) {
+            return false;
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
PR fixes a security issue  Open Redirect via `Referer` Header in `Response::goBack`

## Summary of security issue 

`Typecho\Widget\Response::goBack` redirects users to the value of the `Referer` request header without verifying that the host matches Typecho's own host. Because `Widget\Security::protect()` calls `goBack()` whenever a CSRF token is missing or mismatched, **any `/action/<name>` endpoint can be turned into an open redirect** by a cross-origin page that simply links to it without providing the `_=<token>` parameter. No authentication is required.

## Summary of fix

In `Response::goBack`, only redirect to the `Referer` if its host matches the host the request was served from. Otherwise fall back to `$default` (or `/`). This preserves the legitimate UX (stale-token bounce back) while removing the cross-origin redirect primitive.


## More information regarding the security issue


### 1. `Widget\Security::protect()` — `var/Widget/Security.php:63`

```php
public function protect()
{
    if ($this->enabled && $this->request->get('_') != $this->getToken($this->request->getReferer())) {
        $this->response->goBack();   // <-- redirects on CSRF failure
    }
}
```

Every action handler in `/action/<name>` calls `$this->security->protect()`
near the top of `action()`. When the `_=<token>` query parameter is missing
or stale, `protect()` triggers `goBack()` instead of throwing an error.

### 2. `Typecho\Widget\Response::goBack()` — `var/Typecho/Widget/Response.php:187`

```php
public function goBack(?string $suffix = null, ?string $default = null)
{
    $referer = $this->request->getReferer();

    if (!empty($referer)) {
        // ... optional suffix-merge logic ...
        $this->redirect($referer);    // <-- redirects to raw Referer
    } else {
        $this->redirect($default ?: '/');
    }
}
```

The `Referer` value is passed straight to `redirect()`.

### 3. `Typecho\Widget\Response::redirect()` — line 172

```php
public function redirect(string $location, bool $isPermanently = false)
{
    $location = Common::safeUrl($location);   // strips control chars only
    $this->response->setStatus($isPermanently ? 301 : 302)
        ->setHeader('Location', $location)
        ->respond();
}
```

### 4. `Common::safeUrl()` — `var/Typecho/Common.php:537`

```php
public static function safeUrl($url)
{
    $params = parse_url(str_replace(["\r", "\n", "\t", ' '], '', $url));

    if (isset($params['scheme'])) {
        if (!in_array($params['scheme'], ['http', 'https'])) {
            return '/';
        }
    }
    // strips ", ', <, > and a few other XSS-ish bytes from each URL part
    // ...
    return self::buildUrl($params);
}
```

`safeUrl` only restricts the **scheme** to `http`/`https` and strips
characters that could break out of an HTML attribute (`"`, `'`, `<`, `>`).
It does **not** validate the host. So `https://evil.example/anything`
survives `safeUrl` unchanged.


## Proof of concept

### Attacker page (`https://evil.example/phish.html`)

```html
<!doctype html>
<a href="https://victim.example/index.php/action/login">
  Continue to victim.example login
</a>
```

### Steps

1. Victim browses to `https://evil.example/phish.html` and clicks the link.
2. The browser navigates to
   `https://victim.example/index.php/action/login` with
   `Referer: https://evil.example/phish.html`.
3. `Widget\Action::execute` dispatches to `Widget\Login::action`.
4. `$this->security->protect()` runs. The request has no `_` parameter, so
   the token comparison fails.
5. `protect()` calls `$this->response->goBack()`.
6. `goBack()` reads `Referer: https://evil.example/phish.html`, passes it
   to `redirect()`, which passes it to `safeUrl()`. The scheme is `https`,
   so `safeUrl` returns it unchanged.
7. The server responds with
   **`302 Location: https://evil.example/phish.html`**.

### Repro with `curl`

```text
$ curl -s -o /dev/null -D - \
       -H 'Referer: https://evil.example/anything' \
       'https://victim.example/index.php/action/login'

HTTP/2 302
location: https://evil.example/anything
```

The redirect fires unauthenticated.


