### PR TITLE
Remove dead wellformedweb.org wfw namespace from RSS feed

### DIFF
--- a/var/Typecho/Feed.php
+++ b/var/Typecho/Feed.php
@@ -252,8 +252,7 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">' . self::EOL;
 xmlns:content="http://purl.org/rss/1.0/modules/content/"
 xmlns:dc="http://purl.org/dc/elements/1.1/"
 xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
-xmlns:atom="http://www.w3.org/2005/Atom"
-xmlns:wfw="http://wellformedweb.org/CommentAPI/">
+xmlns:atom="http://www.w3.org/2005/Atom">
 <channel>' . self::EOL;
 
             $content = '';
@@ -291,9 +290,6 @@ xmlns:wfw="http://wellformedweb.org/CommentAPI/">
                 }
 
                 $content .= '<comments>' . $item['link'] . '#comments</comments>' . self::EOL;
-                if (!empty($item['commentsFeedUrl'])) {
-                    $content .= '<wfw:commentRss>' . $item['commentsFeedUrl'] . '</wfw:commentRss>' . self::EOL;
-                }
 
                 if (!empty($item['suffix'])) {
                     $content .= $item['suffix'];


### PR DESCRIPTION
## 问题

电信天翼云等安全扫描把站点 RSS Feed 报为「恶意广告」(#1981)。

根因:RSS 2.0 输出里声明并使用了 `wfw` 命名空间,指向 `http://wellformedweb.org/CommentAPI/`。该域名早已过期并被博彩/广告站抢注,安全扫描器读到 Feed 中的这个 URL 就判定为恶意链接。WordPress 也曾遇到[同样的问题](https://core.trac.wordpress.org/ticket/19885)。

## 改动

`var/Typecho/Feed.php` 中移除对 `wellformedweb.org` 的全部引用:

- 删除 RSS 2.0 头部的 `xmlns:wfw="http://wellformedweb.org/CommentAPI/"` 命名空间声明
- 删除 `<wfw:commentRss>` 元素

两者必须一起删除,否则保留 `wfw:` 前缀而无声明会产生无效 XML。

## 影响

评论 Feed 的能力不受影响:Atom 输出仍通过标准的 `<link rel="replies" type="application/atom+xml">` 暴露评论源。

Fixes #1981