### PR TITLE
Fix XML-RPC editPost creating a new post instead of editing in place

### DIFF
--- a/var/Widget/XmlRpc.php
+++ b/var/Widget/XmlRpc.php
@@ -424,11 +424,11 @@ class XmlRpc extends Contents implements ActionInterface, Hook
         /** 调用已有组件 */
         if ('page' == $type) {
             $widget = PageEdit::alloc(null, $input, function (PageEdit $page) {
-                $page->writePage();
+                $page->prepare()->writePage();
             });
         } else {
             $widget = PostEdit::alloc(null, $input, function (PostEdit $post) {
-                $post->writePost();
+                $post->prepare()->writePost();
             });
         }
 


### PR DESCRIPTION
## 问题

通过 XML-RPC 调用 `metaWeblog.editPost` / `wp.editPost` 编辑已发布文章时,并不会原地更新,而是**新建了一篇文章**(新的 postId),并且作者会被改成当前 XML-RPC 登录用户,进而导致链接、评论归属、作者归属全部变化。(#1973)

## 根因

`var/Widget/XmlRpc.php` 中,所有编辑路径(`mwEditPost`、`wpEditPost`、`wpEditPage`)最终都汇入 `mwNewPost()`。它会把 `postId` 写入 `$input['cid']`,但回调直接调用 `$post->writePost()` / `$page->writePage()`,**跳过了 `prepare()`**。

后台管理走的是 `Post\Edit::action()` —— `$this->on(...)->prepare()->writePost()`,先 `prepare()`:

- `prepare()` → `prepareEdit()` 根据请求里的 `cid` 把已有文章载入 widget;
- `writePost()` → `publish()` 用 `$this->have()` 决定 `update()` 还是 `insert()`。

XML-RPC 路径漏掉 `prepare()`,widget 未载入任何文章 → `have()` 为 false → 走 `insert()` 新建。`insert()` 还会把作者设为当前用户,这就解释了作者被改的现象。

## 改动

把 `mwNewPost` 的两个回调改为 `prepare()->writePage()` / `prepare()->writePost()`,使 XML-RPC 与后台行为一致:

- **新建**:请求无 `cid`,`prepareEdit()` 直接 no-op,保持 `insert()` 新建;
- **编辑**:请求有 `cid`,载入已有文章后 `update()` 原地更新,postId 与作者保持不变;
- 附带:编辑他人文章会经过 `prepareEdit()` 里的 `allow('edit')` 权限校验,而非静默新建副本。

Fixes #1973