### PR TITLE
Fixes for some issues

### DIFF
--- a/var/Widget/Archive.php
+++ b/var/Widget/Archive.php
@@ -1386,6 +1386,13 @@ EOF;
         /** 挂接插件 */
         self::pluginHandle()->call('beforeRender', $this);
 
+        /** 校验模板路径是否在主题目录内, 防止历史脏数据导致的本地文件包含 */
+        $realThemeDir = realpath($this->themeDir);
+        $realPath = realpath($this->themeDir . $this->themeFile);
+        if ($realPath && strpos($realPath, $realThemeDir . DIRECTORY_SEPARATOR) !== 0) {
+            throw new WidgetException(_t('非法的模板路径'), 500);
+        }
+
         /** 输出模板 */
         require_once $this->themeDir . $this->themeFile;
 

--- a/var/Widget/Contents/Attachment/Edit.php
+++ b/var/Widget/Contents/Attachment/Edit.php
@@ -197,7 +197,7 @@ class Edit extends Contents implements ActionInterface
      * @return string
      * @throws \Typecho\Db\Exception|Exception
      */
-    protected function getPageOffsetQuery(int $cid, string $status = null): string
+    protected function getPageOffsetQuery(int $cid, ?string $status = null): string
     {
         return 'page=' . $this->getPageOffset(
             'cid',

--- a/var/Widget/Contents/Page/Edit.php
+++ b/var/Widget/Contents/Page/Edit.php
@@ -62,6 +62,14 @@ class Edit extends Contents implements ActionInterface
         $contents['visibility'] = ('hidden' == $contents['visibility'] ? 'hidden' : 'publish');
         $contents['parent'] = $this->getParent();
 
+        /** 白名单校验自定义模板字段, 防止目录穿越导致的本地文件包含 */
+        if (!empty($contents['template'])) {
+            $validTemplates = array_keys($this->getTemplates());
+            if (!in_array($contents['template'], $validTemplates, true)) {
+                $contents['template'] = null;
+            }
+        }
+
         if ($this->request->is('markdown=1') && $this->options->markdown) {
             $contents['text'] = '<!--markdown-->' . $contents['text'];
         }

--- a/var/Widget/Feedback.php
+++ b/var/Widget/Feedback.php
@@ -308,9 +308,9 @@ class Feedback extends Comments implements ActionInterface
             'status' => $this->options->commentsRequireModeration ? 'waiting' : 'approved'
         ];
 
-        $trackback['author'] = $this->request->filter('trim')->get('blog_name');
+        $trackback['author'] = Common::removeXSS($this->request->filter('trim')->get('blog_name'));
         $trackback['url'] = $this->request->filter('trim', 'url')->get('url');
-        $trackback['text'] = $this->request->get('excerpt');
+        $trackback['text'] = Common::removeXSS(strip_tags($this->request->get('excerpt')));
 
         //检验格式
         $validator = new Validate();


### PR DESCRIPTION
## 自定义模板字段本地文件包含（LFI）

### 原理

Typecho 支持为独立页面（Page）指定自定义渲染模板，该配置通过数据库字段 `template` 存储，取值如 `page.php`、`archive.php` 等。在页面渲染阶段，系统将该值直接拼接到主题目录路径后，通过 `require_once` 执行文件包含操作：

```php
// Archive::render() — 修复前
require_once $this->themeDir . $this->themeFile;
```

由于服务端未对 `template` 值执行任何白名单校验或路径归一化检查，攻击者可通过构造恶意 payload（如 `../../../config.inc.php` 或 `....//....//config.inc.php`）实现目录穿越，最终使 `require_once` 包含 Web 目录外的任意文件。该漏洞同时存在两条攻击路径：**写入时注入**（通过管理接口或伪造请求写入脏数据至数据库）与 **历史数据复用**（数据库中已存储的恶意 template 值在每次页面访问时触发）。

### 攻击链路

```mermaid
sequenceDiagram
    participant A as 攻击者
    participant S as Typecho 服务端

    A->>S: ① POST 请求<br/>(do=publish, template=../../../config.inc.php)
    Note over S: ② writePage() 接收参数<br/>[漏洞点: 无白名单校验]<br/>template 直接入库
    S-->>A: ③ 返回成功响应

    A->>S: ④ 访问目标页面
    Note over S: ⑤ render() 读取 template<br/>[漏洞点: 无路径边界检查]<br/>require_once(themeDir + template)<br/>→ 包含 config.inc.php
    S-->>A: ⑥ 返回数据库凭据等敏感信息
```

### 修复方案

采用**纵深防御**策略，在写入端与渲染端分别部署校验逻辑，确保即使单层防线被绕过仍能阻断攻击。

#### 修复点 A：写入端白名单校验

**文件**：[var/Widget/Contents/Page/Edit.php](var/Widget/Contents/Page/Edit.php#L65-L71)

在 `writePage()` 方法中，从请求数据取出 `template` 字段后，调用 `getTemplates()` 获取当前主题下所有合法的自定义模板文件列表（该方法通过扫描主题目录中标记为 `custom` 的 `.php` 文件生成白名单），随后使用 `in_array` 进行严格类型比对。不在白名单中的值统一置为 `null`，确保非法字符串无法进入数据库。

```php
/** 白名单校验自定义模板字段, 防止目录穿越导致的本地文件包含 */
if (!empty($contents['template'])) {
    $validTemplates = array_keys($this->getTemplates());
    if (!in_array($contents['template'], $validTemplates, true)) {
        $contents['template'] = null;
    }
}
```

此修复阻断了攻击路径①→②，使新写入的恶意 template 值无法持久化。

#### 修复点 B：渲染端路径边界校验

**文件**：[var/Widget/Archive.php](var/Widget/Archive.php#L1389-L1394)

在 `render()` 方法的 `require_once` 调用之前，对拼接后的完整模板路径执行 `realpath()` 归一化解析，消除 `..`、符号链接等路径穿越手段的影响，并验证解析后的绝对路径是否以主题目录的真实路径为前缀。若检测到路径逃逸出主题目录范围，则抛出异常拒绝渲染。

```php
/** 校验模板路径是否在主题目录内, 防止历史脏数据导致的本地文件包含 */
$realThemeDir = realpath($this->themeDir);
$realPath = realpath($this->themeDir . $this->themeFile);
if ($realPath && strpos($realPath, $realThemeDir . DIRECTORY_SEPARATOR) !== 0) {
    throw new WidgetException(_t('非法的模板路径'), 500);
}
```

此修复阻断了攻击路径④→⑤，对数据库中已存在的历史脏数据同样有效。需要注意的是，`themeFile` 的赋值来源除自定义模板外，还包含 `archiveType`、`archiveSlug` 等内部逻辑生成的硬编码文件名（如 `index.php`、`category.php`），这些路径均为程序内部确定的合法值，不包含用户输入，因此 `realpath` 检查不会对其产生误判。

### 修复后防御架构

```mermaid
flowchart TB
    subgraph L1["第一道防线 — 写入端（防新注入）"]
        direction TB
        A1["writePage() 接收 template 参数"] --> A2{"in_array(template,<br/>getTemplates())"}
        A2 -- "在白名单" --> A3["正常入库"]
        A2 -- "不在白名单" --> A4["置 null 后入库"]
    end

    subgraph L2["第二道防线 — 渲染端（防历史脏数据）"]
        direction TB
        B1["render() 读取 themeFile"] --> B2["realpath(themeDir + themeFile)"]
        B2 --> B3{"前缀匹配<br/>startsWith(realPath, realThemeDir)"}
        B3 -- "在主题目录内" --> B4["require_once 正常执行"]
        B3 -- "逃逸主题目录" --> B5["抛出异常<br/>阻断文件包含"]
    end

    L1 -->|"无论第一道防线结果"| L2
```

---

## Trackback 存储型跨站脚本攻击（Stored XSS）

### 原理

Trackback 是 Typecho 实现的一种站点间内容引用通知机制，允许外部站点向文章发送引用通告。与 Pingback 不同的是，Trackback 采用标准 HTTP POST 请求交互，**不需要任何身份认证或 CSRF Token**。处理 Trackback 请求的核心方法位于 [Feedback::trackback()](var/Widget/Feedback.php#L285-L354)，该方法从请求中提取 `blog_name`（来源站点名称）、`url`（来源地址）、`excerpt`（引用摘要）三个字段后，经过基础的格式校验便直接写入评论表。

关键缺陷在于 `excerpt` 与 `blog_name` 字段仅经过了 `trim` / `maxLength` / `xssCheck`（仅检查字符集合法性，不做内容过滤）等弱校验，**未执行任何 HTML 标签清除或 XSS 关键字过滤操作**。而同项目中的 Pingback 实现（[IXR/Pingback.php](var/IXR/Pingback.php#L77)）对同等用途的标题与内容字段均使用了 `Common::removeXSS(strip_tags(...))` 进行双重净化——这一保护措施在 Trackback 分支中被遗漏。

当管理员在后台查看评论列表，或普通用户在前台浏览文章评论区时，存储在数据库中的恶意 HTML/JavaScript 代码将被浏览器解析执行，导致 Cookie 窃取、会话劫持、管理面板接管等后果。

### 攻击链路

```mermaid
sequenceDiagram
    participant Attacker as 攻击者
    participant Server as Typecho 服务端
    participant Admin as 受害者（管理员）

    Attacker->>Server: ① POST Trackback 请求<br/>(无认证, 无CSRF Token)<br/>excerpt=<a href="javascript:alert(1)">click</a>
    Note over Server: ② trackback() 接收<br/>[漏洞点: 无XSS过滤]<br/>excerpt 原样写入评论表
    Server-->>Attacker: ③ <success>0</success>

    Server->>Admin: ④ 管理员打开评论管理页<br/>页面加载评论列表
    Note over Admin: ⑤ 浏览器渲染 excerpt<br/>JavaScript 自动执行<br/>→ Cookie / Session被盗
```

### 修复方案

**文件**：[var/Widget/Feedback.php](var/Widget/Feedback.php#L311-L313)

在 `trackback()` 方法中对输入字段追加与 Pingback 一致的 XSS 过滤策略：先使用 PHP 内置函数 `strip_tags()` 移除所有 HTML 标签，再经由 `Common::removeXSS()` 对残留内容执行关键字粉碎（将 `javascript`、`vbscript`、`on*` 事件处理器等危险词汇替换为无害形式）。两层过滤互补运作——`strip_tags()` 处理结构化 HTML 注入，`removeXSS()` 兜底防范编码绕过与协议注入。

```php
// 修复前
$trackback['author'] = $this->request->filter('trim')->get('blog_name');
$trackback['text']   = $this->request->get('excerpt');

// 修复后
$trackback['author'] = Common::removeXSS($this->request->filter('trim')->get('blog_name'));
$trackback['text']   = Common::removeXSS(strip_tags($this->request->get('excerpt')));
```

---

## var/Widget/Contents/Attachment/Edit.php 第 200 行，方法 getPageOffsetQuery() 为空时报错

PHP 8.4 废弃了 隐式可空参数 （Implicitly Nullable Parameter）。即当参数使用 $param = null 默认值但没有在类型前加 ? 时，会触发此警告。

var/Widget/Contents/Attachment/Edit.php 第 200 行，方法 getPageOffsetQuery() 。

```php
    /**
     * 获取页面偏移的URL Query
     *
     * @param integer $cid 文件id
     * @param string|null $status 状态
     * @return string
     * @throws \Typecho\Db\Exception|Exception
     */
    protected function getPageOffsetQuery(int $cid, string $status = null): string
    {
```

---

## 修复文件清单

| 文件 | 修复类型 | 影响范围 |
|------|---------|---------|
| `var/Widget/Contents/Page/Edit.php` L65-71 | 新增白名单校验 | 阻止非法 template 值写入数据库 |
| `var/Widget/Archive.php` L1389-L1394 | 新增路径边界校验 | 阻止任意文件包含 |
| `var/Widget/Feedback.php` L311-L313 | 新增 XSS 过滤 | 阻止 Trackback 存储型 XSS |
| `var/Widget/Contents/Attachment/Edit.php` L200 | 修复空值保护 | 阻止 PHP8.4 及以上报错 |

---

## 参考

https://github.com/typecho/typecho/issues/1987

https://github.com/typecho/typecho/issues/1977

https://github.com/typecho/typecho/pull/1985