### PR TITLE
Handle invalid UTF-8 in comment edit JSON

### DIFF
--- a/admin/manage-comments.php
+++ b/admin/manage-comments.php
@@ -110,7 +110,7 @@ $isAllComments = ('on' == $request->get('__typecho_all_comments') || 'on' == \Ty
                             'text'      =>  $comments->text
                         );
 
-                        echo htmlspecialchars(json_encode($comment));
+                        echo htmlspecialchars(json_encode($comment, JSON_INVALID_UTF8_SUBSTITUTE));
                         ?>">
                             <td valign="top" class="kit-hidden-mb">
                                 <input type="checkbox" value="<?php $comments->coid(); ?>" name="coid[]"/>


### PR DESCRIPTION
## Summary
- encode admin comment row data with JSON_INVALID_UTF8_SUBSTITUTE
- prevent invalid UTF-8 in comment fields from making json_encode fail and leaving data-comment empty

## Root cause
The comment management page serializes comment fields into the data-comment attribute for editing. When a stored comment contains invalid UTF-8, json_encode can fail and return false, which leaves the attribute without usable JSON.

## Validation
- git diff --check
- php -l was not run because php is not installed in this local environment

Fixes #1893